### PR TITLE
init dream2nix integration templates + tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,18 @@ jobs:
       - name: "Advanced Example: Test with Cabal"
         run: "nix develop -L --command cabal test all"
         working-directory: "./my-example-haskell-lib-advanced/"
+
+  dream2nix-integration:
+    name: nix / ubuntu-latest / dream2nix integration test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: "run dream2nix integration test"
+        run: nix run .#dream2nix-integration-test

--- a/dream2nix/builder.nix
+++ b/dream2nix/builder.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  ...
+}: {
+  config.builders.stacklock2nix-builder = {
+    type = "pure";
+    name = "stacklock2nix-builder";
+    subsystem = "haskell";
+
+    build = {
+      pkgs,
+      ### FUNCTIONS
+      # AttrSet -> Bool) -> AttrSet -> [x]
+      getCyclicDependencies, # name: version: -> [ {name=; version=; } ]
+      getDependencies, # name: version: -> [ {name=; version=; } ]
+      getSource, # name: version: -> store-path
+      # to get information about the original source spec
+      getSourceSpec, # name: version: -> {type="git"; url=""; hash="";}
+      ### ATTRIBUTES
+      # the contentd of the `_subsystem` field of the dream-lock
+      subsystemAttrs, # attrset
+      defaultPackageName, # string
+      defaultPackageVersion, # string
+      # all exported (top-level) package names and versions
+      # attrset of pname -> version,
+      packages,
+      # all existing package names and versions
+      # attrset of pname -> versions,
+      # where versions is a list of version strings
+      packageVersions,
+      # function which applies overrides to a package
+      # It must be applied by the builder to each individual derivation
+      # Example:
+      #   produceDerivation name (mkDerivation {...})
+      produceDerivation,
+      ...
+    }: let
+      l = lib // builtins;
+
+      # TODO: replace with stacklock2nix builder
+      makeTopLevelPackage = pname: version: let
+        deps = getDependencies pname version;
+        depsSources = map ({
+          name,
+          version,
+        }:
+          getSource name version)
+        deps;
+      in
+        pkgs.runCommand
+        pname
+        {}
+        # Completely useless build logic for demo purposes
+        ''
+          mkdir $out
+          for dep in ${toString depsSources}; do
+            cp -r $dep $out/$(basename $dep)
+          done
+        '';
+
+      allPackages =
+        l.mapAttrs
+        (
+          name: ver: {
+            ${ver} = makeTopLevelPackage name ver;
+          }
+        )
+        packages;
+    in {
+      packages = allPackages;
+    };
+  };
+}

--- a/dream2nix/example/flake.nix
+++ b/dream2nix/example/flake.nix
@@ -1,0 +1,37 @@
+{
+  inputs = {
+    dream2nix.url = "github:nix-community/dream2nix";
+    stacklock2nix.url = "github:cdepillabout/stacklock2nix";
+
+    # some example project containing a stack.yaml.lock
+    src.url = "github:NorfairKing/cabal2json";
+    src.flake = false;
+  };
+
+  outputs = {
+    self,
+    dream2nix,
+    stacklock2nix,
+    src,
+  } @ inp:
+    (dream2nix.lib.makeFlakeOutputs {
+      systems = ["x86_64-linux"];
+      config.projectRoot = ./.;
+      config.modules = [
+        stacklock2nix.modules.dream2nix.stacklock2nix-translator
+        stacklock2nix.modules.dream2nix.stacklock2nix-builder
+      ];
+      source = src;
+      projects = {
+        cabal2json = {
+          name = "cabal2json";
+          subsystem = "haskell";
+          translator = "stacklock2nix-translator";
+          builder = "stacklock2nix-builder";
+        };
+      };
+    })
+    // {
+      # checks.x86_64-linux.linemd = self.packages.x86_64-linux.linemd;
+    };
+}

--- a/dream2nix/integration-test.nix
+++ b/dream2nix/integration-test.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  l = lib // builtins;
+
+  testScript = pkgs.writeScript "test-dream2nix-integration" ''
+    set -Eeuo pipefail
+    PATH="${lib.makeBinPath [
+      pkgs.coreutils
+      pkgs.git
+      pkgs.nix
+    ]}"
+
+    set -x
+
+    example="${./example}"
+    args="--override-input dream2nix /home/grmpf/projects/github/dream2nix --override-input stacklock2nix ${../.} --no-write-lock-file --allow-import-from-derivation --tarball-ttl 0"
+
+    # test if nix can render the flake
+    nix flake show $args $example
+
+    # resolve default package to dream-lock.json
+    # This will verify the dream-lock against the jsonschema
+    nix run $args $example#default.resolve
+
+    # build default package from dream-lock.json without IFD
+    nix build $args --no-allow-import-from-derivation $example#default
+
+    # build default package on-the-fly
+    rm -rf ./dream2nix-packages
+    nix build $args $example#default
+  '';
+
+  test-app.type = "app";
+  test-app.program = toString testScript;
+in
+  test-app

--- a/dream2nix/integration-test.nix
+++ b/dream2nix/integration-test.nix
@@ -16,7 +16,7 @@
     set -x
 
     example="${./example}"
-    args="--override-input dream2nix /home/grmpf/projects/github/dream2nix --override-input stacklock2nix ${../.} --no-write-lock-file --allow-import-from-derivation --tarball-ttl 0"
+    args="--update-input dream2nix --override-input stacklock2nix ${../.} --no-write-lock-file --allow-import-from-derivation"
 
     # test if nix can render the flake
     nix flake show $args $example

--- a/dream2nix/translator.nix
+++ b/dream2nix/translator.nix
@@ -1,0 +1,242 @@
+{
+  dlib,
+  lib,
+  # pkgs are needed for IFD operations
+  pkgs,
+  ...
+}: let
+  l = lib // builtins;
+in {
+  config.translators.stacklock2nix-translator = {
+    type = "ifd";
+    subsystem = "haskell";
+    name = "stacklock2nix-translator";
+
+    # translate from a given source and a project specification to a dream-lock.
+    translate = {
+      /*
+      A list of projects returned by `discoverProjects`
+      Example:
+        {
+          "name": "optimism",
+          "relPath": "",
+          "subsystem": "nodejs",
+          "subsystemInfo": {
+            "workspaces": [
+              "packages/common-ts",
+              "packages/contracts",
+              "packages/core-utils",
+            ]
+          }
+        }
+      */
+      project,
+      /*
+      Entire source tree represented as nested attribute set.
+      (produced by `dlib.prepareSourceTree`)
+
+      This has the advantage that files will only be read/parsed once, even
+      when accessed multiple times or by multiple translators.
+
+      Example:
+        {
+          files = {
+            "package.json" = {
+              relPath = "package.json"
+              fullPath = "${source}/package.json"
+              content = ;
+              jsonContent = ;
+              tomlContent = ;
+            }
+          };
+
+          directories = {
+            "packages" = {
+              relPath = "packages";
+              fullPath = "${source}/packages";
+              files = {
+                ...
+              };
+              directories = {
+                ...
+              };
+            };
+          };
+
+          # returns the tree object of the given sub-path
+          getNodeFromPath = path: ...
+        }
+      */
+      tree,
+      /*
+      arguments defined in `extraArgs` specified by user
+      (see definition for `extraArgs` near the bottom of this file)
+      */
+      noDev,
+      theAnswer,
+      ...
+    }: let
+      # get the root source and project source
+      rootSource = tree.fullPath;
+      projectSource = "${tree.fullPath}/${project.relPath}";
+      projectTree = tree.getNodeFromPath project.relPath;
+
+      # fromYaml IFD implementation
+      fromYaml = file: let
+        file' = l.path {path = file;};
+        jsonFile = pkgs.runCommandLocal "yaml.json" {} ''
+          ${pkgs.yaml2json}/bin/yaml2json < ${file'} > $out
+        '';
+      in
+        l.fromJSON (l.readFile jsonFile);
+
+      # use dream2nix' source tree abstraction to access json content of files
+      stackLockText =
+        (projectTree.getNodeFromPath "stack.yaml.lock").content;
+
+      stackLock = fromYaml stackLockText;
+
+      /*
+
+      Define the name and version of the top-level package.
+      If there are multiple top-level packages, just pick any of them.
+      Dream2nix requires one package to be the default package.
+      TODO: set values dynamically.
+      */
+      defaultPackageName = "my-stacklock2nix-package";
+      defaultPackageVersion = "unknown-version";
+    in
+      # see example in src/specifications/dream-lock-example.json
+      {
+        /*
+        Tell dream2nix that this is the human-readable (decompressed)
+        representation of the dream-lock.
+        */
+        decompressed = true;
+
+
+        # generic fields
+        _generic = {
+          # TODO: specify the default package name
+          defaultPackage = defaultPackageName;
+
+          # the location of the package within the source tree
+          location = project.relPath;
+
+          # TODO: specify a list of exported packages and their versions
+          packages = {
+            "${defaultPackageName}" = defaultPackageVersion;
+          };
+
+          # TODO: this must be equivalent to the subsystem name
+          subsystem = "haskell";
+        };
+
+        /*
+        Store subsystem specific data.
+        This is needed if the subsystem requires extra metadata to be stored.
+        This will be a free-form field as long as no jsonschema exists for
+        this subsystem.
+        TODO: create a jsonschema for the current subsystem under
+        /src/specifications/{subsystem}/dream-lock-schema.json
+        */
+        _subsystem = {
+          example-key = "example-value";
+        };
+
+        /*
+        List dependency edges that need to be removed in order to prevent
+        infinite recursions in the nix evaluator.
+        Usually this can be omitted.
+        */
+        cyclicDependencies = {};
+
+        /*
+        Define the dependency graph.
+        This can be set to `{}`, in which case dream2nix assumes that:
+        - all sources listed in `sources` represent one dependency
+        - all dependencies are direct dependenceis of the `defaultPackage`
+        Example:
+          # foo-1.2.3 depends on bar-2.3.4 and baz-3.4.5
+          {
+            foo."1.2.3" = [
+              {name = "bar"; version = "2.3.4"}
+              {name = "baz"; version = "3.4.5"}
+            ]
+            ...
+          }
+        */
+        dependencies = {
+          ${defaultPackageName}.${defaultPackageVersion} =
+            l.mapAttrsToList
+            (
+              sourceName: source: {
+                name = sourceName;
+                version = source.rev or "unknown-version";
+              }
+            )
+            # TODO: implement this
+            {};
+        };
+
+        /*
+        Define the sources for all dependencies including their checksums.
+        This allows dream2nix to fetch all sources reproducibly.
+        Each dependency specified in `dependencies` must have a corresponding
+        entry in `sources` which describes how the source can be fetched.
+        Check the `fetchers` section in the docs to see what fetchers are
+        supported and which arguments they require.
+        Example:
+          {
+            foo."1.2.3" = {
+              type = "http";
+              url = "https://foo.com/tarball.tar.gz";
+              hash = "sha256:000000000000000000000000000000000000000";
+            };
+            bar."2.3.4" = {
+              ...
+            }
+            ...
+          }
+        */
+        sources =
+          l.mapAttrs
+          (sourceName: source: {
+            ${source.rev or "unknown-version"} = {
+              type = "archive";
+              url = source.url;
+              hash = "sha256:${source.sha256}";
+            };
+          })
+          # TODO: Implement this
+          {};
+      };
+
+    # If the translator requires additional arguments, specify them here.
+    # Users will be able to set these arguments via `settings`.
+    # There are only two types of arguments:
+    #   - string argument (type = "argument")
+    #   - boolean flag (type = "flag")
+    # String arguments contain a default value and examples. Flags do not.
+    # Flags are false by default.
+    extraArgs = {
+      # Example: boolean option
+      # Flags always default to 'false' if not specified by the user
+      noDev = {
+        description = "Exclude dev dependencies";
+        type = "flag";
+      };
+
+      # Example: string option
+      theAnswer = {
+        default = "42";
+        description = "The Answer to the Ultimate Question of Life";
+        examples = [
+          "0"
+          "1234"
+        ];
+        type = "argument";
+      };
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,24 @@
 {
   "nodes": {
-    "root": {}
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1671131270,
+        "narHash": "sha256-QCN2Wfa5i1iZThSSGtBdBcKWDfCMOvBHIKtorMaqGPA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8ba90bbc63e58c8c436f16500c526e9afcb6b00a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
   },
   "root": "root",
   "version": 7

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,19 @@
 {
   description = "Nix library for generating a Nixpkgs Haskell package set from a stack.yaml.lock file";
 
-  outputs = { self }: {
+  outputs = { self, nixpkgs, }: {
     # A Nixpkgs overlay.  This contains the stacklock2nix function that
     # end-users will want to use.
     overlay = import ./nix/overlay.nix;
+
+    # expose dream2nix modules for external use
+    modules.dream2nix.stacklock2nix-translator = ./dream2nix/translator.nix;
+    modules.dream2nix.stacklock2nix-builder = ./dream2nix/builder.nix;
+
+    # This app is an integration test for dream2nix to be executed in CI
+    apps.x86_64-linux.dream2nix-integration-test = import ./dream2nix/integration-test.nix {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      lib = nixpkgs.lib ;
+    };
   };
 }


### PR DESCRIPTION
This PR initializes templates for integration with dream2nix and adds a test that can be executed via:
`nix run .#dream2nix-integration-test`.

I do not intend to complete this PR, but it can serve as a starting point for whoever wants to take on the work, and can be used for discussions. 
The templates for the translator and builder are largely just copied from `dream2nix/src/templates/...`, and contain only minor modifications.

Usually we commit the modules for ecosystem support like these, directly to the dream2nix source itself, but as I understood you, @cdepillabout, the intention is to keep the stacklock2nix project separate. Therefore the PR adds the dream2nix modules to the stacklock2nix project itself and exposes them via the flake outputs. Feel free anytime to move this whole project inside dream2nix and maintain it from there, if you feel comfortable with that.

Some comments in the templates contain references to other files, like examples or specifications. Those references are relative to the source of the upstream dream2nix project.

In general, some more detailed guide on contributing ecosystem support to dream2nix can be found [here](https://nix-community.github.io/dream2nix/contributing/contributing.html)

## Short Summary
The purpose of the translator is to extract data from any given project source (by parsing the stack.yaml.lock for example) and return the extracted data via the dream-lock format, which is JSON serializable.
The specification of the dream-lock format can be found at  [dream2nix/src/specifications](https://github.com/nix-community/dream2nix/tree/main/src/specifications)
A successful termination of the .#dream2nix-integration-test app implies that the dream-lock format produced by the translator is correct.

The purpose of the builder is to read the data represented by the dream-lock and generate nix `packages` and `devShells` from it.
The builder accesses the dream-lock indirectly through getter functions like `getDependencies` etc. which are provided by dream2nix (see builder template below).

Now there is a clean way and a dirty way of integrating stacklock2nix into dream2nix.
The dream-lock format contains fields like `dependencies` and `sources`, for which the format is strict. If those fields are used, it will:
- allow dream2nix to take care of fetching dependencies
- allow dream2nix to provides interfaces like `inject` and `sourceOverrides` allowing the user to manipulate the the dependency tree and sources
- ensure compatibility between different translators and builders for haskell in dream2nix

Besides these strict fields, the dream-lock also offers the `_subsystem` field, which can be used as a free-form field. So the quick and dirty way would be to ignore some fields of the dream-lock and instead put data into `_subsystem`. That would work around some of the requirements of dream2nix but kill some features and general compatibility with other haskell modules.

It would be great to do it the clean way, so we can re-use the stacklock2nix builder for example with other translators like `cabal-plan` etc. and we won't have to do the work twice.

Feel free to comment if you have any more questions.