### PR TITLE
Add method for creating completely new package set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,10 @@ jobs:
         run: "nix develop -L --command cabal test all"
         working-directory: "./my-example-haskell-lib-advanced/"
 
+      - name: "Tests"
+        run: "nix-build"
+        working-directory: "./test/"
+
   nix-commit-from-flake-lock:
     name: nix / ubuntu-latest / using stacklock2nix commit from flake.lock
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Nix result files
-/result
+result
+result-*
 
 # Haskell .gitignore
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 1.1.0
+
+*   Added two new attributes to the attribute set returned from a call to
+    `stacklock2nix`: `newPkgSet` and `newPkgSetDevShell`.  These two values are
+    similar to the existing `pkgSet` and `devShell` attributes.  Whereas
+    `pkgSet` and `devShell` take the `baseHaskellPkgSet` argument and overlay
+    it with package overrides created from your `stack.yaml` file, `newPkgSet`
+    and `newPkgSetDevShell` are a completely new package set, containing _only_
+    packages from your `stack.yaml`.
+
+    The effect of this is that `pkgSet` will contain packages that are in
+    Nixpkgs, but not in Stackage.  For instance, when using `pkgSet`, you
+    should be able to access the package
+    [`pkgSet.termonad`](https://hackage.haskell.org/package/termonad) because
+    it is available on Hackage (and in Nixpkgs), even though it is not in any
+    Stackage resolver.
+
+    However, `newPkgSet` will only contain packages in your `stack.yaml` file.
+    For instance, you'll never be able to access `newPkgSet.termonad` or
+    `newPkgSet.spago`, because they will likely never be available on Stackage.
+
+    In general, in your own projects, should you use `pkgSet` or `newPkgSet`?
+
+    For building your own projects, most of the time `pkgSet` and `newPkgSet`
+    should be similar.  `newPkgSet` may be slightly safer, since there is
+    almost no chance you accidentally use a Haskell package outside of your
+    `stack.yaml`.  `pkgSet` may be slightly more convenient depending on what
+    you're trying to do.
+
 ## 1.0.0
 
 *   This is the 1.0 release of `stacklock2nix`.  I've tested `stacklock2nix` on

--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -36,24 +36,55 @@
 #     for testing, but this is not necessary to build the Haskell library.
 #
 # Please feel free to send PRs adding necessary overrides here.
+#
+# Make sure to keep this list in alphabetical order.
 
 cabal2nixArgsOverrides {
   "gi-cairo" = ver: { cairo = pkgs.cairo; };
+
   "gi-gdk" = ver: { gtk3 = pkgs.gtk3; };
+
   "gi-gio" = ver: { glib = pkgs.glib; };
+
   "gi-glib" = ver: { glib = pkgs.glib; };
+
   "gi-gtk" = ver: { gtk3 = pkgs.gtk3; };
+
   "gi-gmodule" = ver: { gmodule = null; };
+
   "gi-gobject" = ver: { glib = pkgs.glib; };
+
   "gi-harfbuzz" = ver: { harfbuzz-gobject = null; };
+
   "gi-pango" = ver: { cairo = pkgs.cairo; pango = pkgs.pango; };
+
   "gi-vte" = ver: { vte_291 = pkgs.vte; };
+
   "glib" = ver: { glib = pkgs.glib; };
+
   "haskell-gi" = ver: { glib = pkgs.glib; gobject-introspection = pkgs.gobject-introspection; };
+
   "haskell-gi-base" = ver: { glib = pkgs.glib; };
+
+  # The PSQueue and fingertree-psqueue packages are used in benchmarks, but they are not on Stackage.
+  "psqueues" = ver: { fingertree-psqueue = null; PSQueue = null; };
+
   "saltine" = ver: { libsodium = pkgs.libsodium; };
+
   "secp256k1-haskell" = ver: { secp256k1 = pkgs.secp256k1; };
+
   "splitmix" = ver: { testu01 = null; };
+
+  "test-framework" = ver: { libxml = pkgs.libxml; };
+
   "termonad" = ver: { vte_291 = pkgs.vte; gtk3 = pkgs.gtk3; pcre2 = pkgs.pcre2;};
+
+  # unordered-containers uses the Haskell package nothunks in its test-suite,
+  # but nothunks is not in Stackage.  We disable the tests for unordered-containers
+  # in the suggestedOverlay.nix file, but callCabal2Nix is called on it before
+  # suggestedOverlay.nix is applied.  So here we need to just pass in null for
+  # the nothunks dependency, since it won't end up being used.
+  "unordered-containers" = ver: { nothunks = null; };
+
   "zlib" = ver: { zlib = pkgs.zlib; };
 }

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -28,6 +28,8 @@
 # ```
 #
 # These will be maintained on a best-effort basis.  Again, please send PRs.
+#
+# Make sure to keep this list in alphabetical order.
 
 hfinal: hprev: with haskell.lib.compose; {
 
@@ -155,9 +157,6 @@ hfinal: hprev: with haskell.lib.compose; {
 
   nanospec = dontCheck hprev.nanospec;
 
-  # test suite doesn't build
-  nothunks = dontCheck hprev.nothunks;
-
   # circular dependency in tests
   options = dontCheck hprev.options;
 
@@ -212,6 +211,9 @@ hfinal: hprev: with haskell.lib.compose; {
 
   # tests don't support musl
   unix-time = dontCheck hprev.unix-time;
+
+  # Test suite requires the nothunks library, which isn't on stackage.
+  unordered-containers = dontCheck hprev.unordered-containers;
 
   vector = dontCheck hprev.vector;
 

--- a/test/default.nix
+++ b/test/default.nix
@@ -1,0 +1,4 @@
+
+{...}:
+
+(import ./nixpkgs.nix {}).stacklock2nix-tests

--- a/test/nixpkgs.nix
+++ b/test/nixpkgs.nix
@@ -1,0 +1,30 @@
+
+{...}:
+
+let
+  flake-lock = builtins.fromJSON (builtins.readFile ../my-example-haskell-lib-advanced/flake.lock);
+
+  # Use the Nixpkgs that the my-example-haskell-lib-advanced is pinned to.
+  nixpkgs-src = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${flake-lock.nodes.nixpkgs.locked.rev}.tar.gz";
+    sha256 = flake-lock.nodes.nixpkgs.locked.narHash;
+  };
+
+  overlays = [
+    # stacklock2nix overlay
+    (import ../nix/overlay.nix)
+
+    # tests
+    (final: prev: {
+      stacklock2nix-tests =
+        (final.callPackage ./test-new-package-set.nix {}) ++ [
+          # new tests go here
+        ];
+    })
+  ];
+
+  pkgs = import nixpkgs-src { inherit overlays; };
+
+in
+
+pkgs

--- a/test/test-new-package-set.nix
+++ b/test/test-new-package-set.nix
@@ -1,0 +1,43 @@
+
+{ stacklock2nix
+, haskell
+, cabal-install
+, fetchurl
+}:
+
+let
+  hasklib = haskell.lib.compose;
+
+  stacklock = stacklock2nix {
+    stackYaml = ../my-example-haskell-lib-advanced/stack.yaml;
+    baseHaskellPkgSet = haskell.packages.ghc924;
+    additionalHaskellPkgSetOverrides = hfinal: hprev: {
+      # The servant-cassava.cabal file is malformed on GitHub:
+      # https://github.com/haskell-servant/servant-cassava/pull/29
+      servant-cassava =
+        hasklib.overrideCabal
+          { editedCabalFile = null; revision = null; }
+          hprev.servant-cassava;
+
+      amazonka = hasklib.dontCheck hprev.amazonka;
+      amazonka-core = hasklib.dontCheck hprev.amazonka-core;
+      amazonka-sso = hasklib.dontCheck hprev.amazonka-sso;
+      amazonka-sts = hasklib.dontCheck hprev.amazonka-sts;
+    };
+    cabal2nixArgsOverrides = args: args // {
+      amazonka-sso = ver: { amazonka-test = null; };
+      amazonka-sts = ver: { amazonka-test = null; };
+    };
+    additionalDevShellNativeBuildInputs = stacklockHaskellPkgSet: [
+      cabal-install
+    ];
+    all-cabal-hashes = fetchurl {
+      name = "all-cabal-hashes";
+      url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/9ab160f48cb535719783bc43c0fbf33e6d52fa99.tar.gz";
+      sha256 = "sha256-QC07T3MEm9LIMRpxIq3Pnqul60r7FpAdope6S62sEX8=";
+    };
+  };
+in
+[ stacklock.newPkgSet.my-example-haskell-app
+  stacklock.newPkgSetDevShell
+]


### PR DESCRIPTION
This PR adds a method for creating a completely new package set.

Resolves #3.

Up til now, `stacklock2nix` just exposed an overlay you could apply to an existing Nixpkgs Haskell package set.  This PR adds an attribute that exposes a completely new package set.  This new package set doesn't have any of the packages from the standard Nixpkgs Haskell package set.  In some sense, it is "safer" to use than the plain overlay.