### PR TITLE
Look for cabal file in all-cabal-hashes

### DIFF
--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -133,7 +133,12 @@ let
   # file.
   resolverParsed = readYAML resolverRawYaml;
 
-  fetchCabalFileRevision = callPackage ./fetchCabalFileRevision.nix {};
+  fetchCabalFileRevision =
+    let
+      args =
+        lib.optionalAttrs (all-cabal-hashes != null) { inherit all-cabal-hashes; };
+    in
+    callPackage ./fetchCabalFileRevision.nix args;
 
   # Replace the `.cabal` file in a given Haskell package with the revision
   # specified by the given hash.
@@ -792,8 +797,10 @@ in
   # `.Internal` modules in Haskell.
   _internal = {
     inherit
-      snapshotInfo
+      all-cabal-hashes
+      fetchCabalFileRevision
       resolverParsed
+      snapshotInfo
       ;
   };
 }

--- a/nix/build-support/stacklock2nix/fetchCabalFileRevision.nix
+++ b/nix/build-support/stacklock2nix/fetchCabalFileRevision.nix
@@ -42,7 +42,7 @@ stdenvNoCC.mkDerivation {
   builder = writeShellScript "fetchCabalFileRevisionBuilder.sh" ''
     source $stdenv/setup
 
-    set -xeuo pipefail
+    set -euo pipefail
 
 
     # Try to extract the .cabal file for the given revision
@@ -60,7 +60,7 @@ stdenvNoCC.mkDerivation {
     find_cabal_file_in_tar () {
       revId=$1
       tar --wildcards --extract --occurrence=$revId \
-        --file '${all-cabal-hashes}' --verbose --gzip --strip-components=3 \
+        --file '${all-cabal-hashes}' --gzip --strip-components=3 \
         '*/${name}/${version}/${name}.cabal'
     }
 
@@ -128,6 +128,8 @@ stdenvNoCC.mkDerivation {
       rm "${name}.cabal"
     done
 
+    echo "Couldn't find .cabal file revision for ${name}-${version} in all-cabal-hashes.  Fetching from Hackage..."
+
     curlVersion=$(curl -V | head -1 | cut -d' ' -f2)
 
     curl=(
@@ -168,9 +170,7 @@ stdenvNoCC.mkDerivation {
       rm "${name}.cabal"
     done
 
-
-
-    echo "ERROR: Could not find cabal file revision for ${name}-${version} with hash ${hash}."
+    echo "ERROR: Could not find cabal file revision for ${name}-${version} with hash ${hash} in Hackage"
     exit 1
   '';
 }


### PR DESCRIPTION
This PR modifies fetchCabalFileRevision to first look up the .cabal file for each package/version/revision in all-cabal-hashes, and only query Hackage if the .cabal file is not found in all-cabal-hashes.
