### PR TITLE
Make cabal fetcher work with all-cabal-hashes as directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 1.2.0
+
+*   Make sure that `stacklock2nix` will work if the input `all-cabal-hashes`
+    argument is a directory (instead of a tarball).
+
+    Passing `all-cabal-hashes` as a directory will make the initial build
+    process a little faster (although shouldn't affect future rebuilds).
+
+    You can easily pass `all-cabal-hashes` as a directory by pulling it down
+    with `fetchFromGitHub` like the following:
+
+    ```nix
+    final: prev: {
+      my-stacklock2nix-proj = final.stacklock2nix {
+        stackYaml = ./stack.yaml;
+
+        ...
+
+        all-cabal-hashes = final.fetchFromGitHub {
+          owner = "commercialhaskell";
+          repo = "all-cabal-hashes";
+          rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
+          sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
+        };
+      };
+    }
+    ```
+
 ## 1.1.0
 
 *   Added two new attributes to the attribute set returned from a call to

--- a/my-example-haskell-lib-advanced/flake.lock
+++ b/my-example-haskell-lib-advanced/flake.lock
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1670381124,
-        "narHash": "sha256-/eBEJ4VW1gcFbJaA8LP5VbtYCPw16AI9Wtp+cuAt/kM=",
+        "lastModified": 1678756010,
+        "narHash": "sha256-x8tG/lFSnQYlGjE5teGsAMhV4dtAFptbvE7HihtY+jY=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "8677b6d67e5534468d1686fa422d0706f8313d0c",
+        "rev": "5502d766954b8680b01b1feb0518b5cc7869dee7",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-advanced/nix/overlay.nix
+++ b/my-example-haskell-lib-advanced/nix/overlay.nix
@@ -46,10 +46,11 @@ final: prev: {
           amazonka-sts = final.haskell.lib.dontCheck hprev.amazonka-sts;
         })
       ];
-      all-cabal-hashes = final.fetchurl {
-        name = "all-cabal-hashes";
-        url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/9ab160f48cb535719783bc43c0fbf33e6d52fa99.tar.gz";
-        sha256 = "sha256-QC07T3MEm9LIMRpxIq3Pnqul60r7FpAdope6S62sEX8=";
+      all-cabal-hashes = final.fetchFromGitHub {
+        owner = "commercialhaskell";
+        repo = "all-cabal-hashes";
+        rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
+        sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
       };
     });
 

--- a/my-example-haskell-lib-easy/flake.lock
+++ b/my-example-haskell-lib-easy/flake.lock
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1670381124,
-        "narHash": "sha256-/eBEJ4VW1gcFbJaA8LP5VbtYCPw16AI9Wtp+cuAt/kM=",
+        "lastModified": 1678756010,
+        "narHash": "sha256-x8tG/lFSnQYlGjE5teGsAMhV4dtAFptbvE7HihtY+jY=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "8677b6d67e5534468d1686fa422d0706f8313d0c",
+        "rev": "5502d766954b8680b01b1feb0518b5cc7869dee7",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-easy/flake.nix
+++ b/my-example-haskell-lib-easy/flake.nix
@@ -89,10 +89,11 @@
           #
           # If you are using a very recent Stackage resolver and an old Nixpkgs,
           # it is almost always necessary to override `all-cabal-hashes`.
-          all-cabal-hashes = final.fetchurl {
-            name = "all-cabal-hashes";
-            url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/9ab160f48cb535719783bc43c0fbf33e6d52fa99.tar.gz";
-            sha256 = "sha256-QC07T3MEm9LIMRpxIq3Pnqul60r7FpAdope6S62sEX8=";
+          all-cabal-hashes = final.fetchFromGitHub {
+            owner = "commercialhaskell";
+            repo = "all-cabal-hashes";
+            rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
+            sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
           };
         };
 

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -68,14 +68,20 @@
   #
   # Example:
   # ```
-  # final.fetchurl {
-  #   name = "all-cabal-hashes";
-  #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/9ab160f48cb535719783bc43c0fbf33e6d52fa99.tar.gz";
-  #   sha256 = "sha256-QC07T3MEm9LIMRpxIq3Pnqul60r7FpAdope6S62sEX8=";
+  # final.fetchFromGitHub {
+  #   owner = "commercialhaskell";
+  #   repo = "all-cabal-hashes";
+  #   rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
+  #   sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
   # };
   # ```
   #
   # This is not used if `baseHaskellPkgSet` is `null`.
+  #
+  # (NOTE: You likely want to fetch all-cabal-hashes with `fetchFromGitHub`
+  # (instead of something like `fetchurl`) so that the repository is unzipped
+  # and untarred.  stacklock2nix can still work with an all-cabal-hashes that is
+  # a tarball, but building will be faster with a plain directory.)
   all-cabal-hashes ? null
 , callPackage ? topargs.callPackage
 , # Path to Nixpkgs.

--- a/nix/build-support/stacklock2nix/fetchCabalFileRevisionBuilder.sh
+++ b/nix/build-support/stacklock2nix/fetchCabalFileRevisionBuilder.sh
@@ -25,9 +25,15 @@ set -euo pipefail
 # Side effects:
 #   Creates the file "./${haskPkgName}.cabal" if the given revision was found
 #   in the tarball.
-find_cabal_file_in_tar () {
-  tar --wildcards --extract --file "${all_cabal_hashes}" \
-    --gzip --strip-components=3 "*/${haskPkgName}/${haskPkgVer}/${haskPkgName}.cabal"
+find_cabal_file_in_all_cabal_hashes () {
+  if [ -d "${all_cabal_hashes}" ]; then
+    # all-cabal-hashes is a directory.  Directly reference the .cabal file need.
+    cp "${all_cabal_hashes}/${haskPkgName}/${haskPkgVer}/${haskPkgName}.cabal" ./
+  else
+    # all-cabal-hashes is a tarball.  Try to pull out the .cabal file we need.
+    tar --wildcards --extract --file "${all_cabal_hashes}" \
+        --gzip --strip-components=3 "*/${haskPkgName}/${haskPkgVer}/${haskPkgName}.cabal"
+  fi
 }
 
 # Test the hash of the file "./${haskPkgName}.cabal" to see if it is equal to
@@ -72,7 +78,7 @@ copy_cabal_file_to_out_and_exit () {
 # If a .cabal file is found with the correct hash, it is used.  Otherwise,
 # this loop ends when there are no more revision IDs available for the
 # package/version.
-if find_cabal_file_in_tar; then
+if find_cabal_file_in_all_cabal_hashes; then
   # We successfully extracted the tar file, now we see if it has the
   # correct hash.
   if test_hash ; then

--- a/test/nixpkgs.nix
+++ b/test/nixpkgs.nix
@@ -17,12 +17,20 @@ let
     # tests
     (final: prev: {
       stacklock2nix-tests = {
+        # This tests that stacklock2nix correctly outputs `newPkgSet` and
+        # `newPkgSetDevShell` attributes.
+        #
+        # This also tests that all-cabal-hashes works correctly as a tarball (not a directory).
         new-package-set = final.callPackage ./test-new-package-set.nix {};
+
+        # This tests that all-cabal-hashes works correctly as a directory (not a tarball).
+        all-cabal-hashes-is-dir = final.callPackage ./test-all-cabal-hashes-is-dir.nix {};
       };
 
       # A list of all stacklock2nix tests.  This makes it easy to build all
       # tests with a single call to `nix-build`.
-      all-stacklock2nix-tests = builtins.attrValues final.stacklock2nix-tests;
+      all-stacklock2nix-tests =
+        final.lib.flatten (builtins.attrValues final.stacklock2nix-tests);
     })
   ];
 

--- a/test/test-all-cabal-hashes-is-dir.nix
+++ b/test/test-all-cabal-hashes-is-dir.nix
@@ -1,14 +1,14 @@
 { stacklock2nix
 , haskell
 , cabal-install
-, fetchurl
+, fetchFromGitHub
 }:
 
 let
   hasklib = haskell.lib.compose;
 
   stacklock = stacklock2nix {
-    stackYaml = ../my-example-haskell-lib-advanced/stack.yaml;
+    stackYaml = ../my-example-haskell-lib-easy/stack.yaml;
     baseHaskellPkgSet = haskell.packages.ghc924;
     additionalHaskellPkgSetOverrides = hfinal: hprev: {
       # The servant-cassava.cabal file is malformed on GitHub:
@@ -27,19 +27,16 @@ let
       amazonka-sso = ver: { amazonka-test = null; };
       amazonka-sts = ver: { amazonka-test = null; };
     };
-    additionalDevShellNativeBuildInputs = stacklockHaskellPkgSet: [
-      cabal-install
-    ];
-    # XXX: Make sure to keep the call to fetchurl here, since it is partly
+    # XXX: Make sure to keep the call to fetchFromGitHub here, since it is
     # testing that fetchCabalFileRevision is able to handle all-cabal-hashes
-    # being a tarball. (fetchurl makes the output derivation a tarball.)
-    all-cabal-hashes = fetchurl {
-      name = "all-cabal-hashes";
-      url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/80869091dcb9f932c15fe57e30d4d0730c5f87df.tar.gz";
-      sha256 = "sha256-FI1Z1zMPnOXRBAPJiSI5VIyH6JkOuY9Cu1qdq1vwjK0=";
+    # being a directory.  (fetchFromGitHub makes the output derivation a
+    # directory.)
+    all-cabal-hashes = fetchFromGitHub {
+      owner = "commercialhaskell";
+      repo = "all-cabal-hashes";
+      rev = "80869091dcb9f932c15fe57e30d4d0730c5f87df";
+      sha256 = "sha256-LAD3/5qeJWbzfqkcWccMOq0pHBnSkNnvBjWnlLzWFvQ=";
     };
   };
 in
-[ stacklock.newPkgSet.my-example-haskell-app
-  stacklock.newPkgSetDevShell
-]
+stacklock.newPkgSet.my-example-haskell-app


### PR DESCRIPTION

This PR does the following:

- Make sure `fetchCabalFileRevisionBuilder.sh` can handle `all-cabal-hashes` as a directory (in addition to a raw tarball).
- Add test for all-cabal-hash being a directory and tarball.
- Change examples in this repo to use `fetchFromGitHub` instead of `fetchurl` for `all-cabal-hashes`.
