### PR TITLE
Add all-cabal-hashes as output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 1.3.0
+
+*   Add `all-cabal-hashes` as an output from `stacklock2nix`.  This can be
+    used as in the ["advanced" example](./my-example-haskell-lib-advanced/nix/overlay.nix):
+
+    ```nix
+    final: prev: {
+      my-example-haskell-stacklock = final.stacklock2nix {
+        stackYaml = ../stack.yaml;
+        all-cabal-hashes = final.fetchFromGitHub {
+          owner = "commercialhaskell";
+          repo = "all-cabal-hashes";
+          rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
+          sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
+        };
+      };
+
+      my-example-haskell-pkg-set = final.haskell.packages.ghc924.override (oldAttrs: {
+        inherit (final.my-example-haskell-stacklock) all-cabal-hashes;
+        ...
+    ```
+
+    Added in [#19](https://github.com/cdepillabout/stacklock2nix/pull/19).
+
 ## 1.2.0
 
 *   Make sure that `stacklock2nix` will work if the input `all-cabal-hashes`
@@ -25,6 +49,10 @@
       };
     }
     ```
+
+    Implemented in [#15](https://github.com/cdepillabout/stacklock2nix/pull/15),
+    [#16](https://github.com/cdepillabout/stacklock2nix/pull/16), and
+    [#17](https://github.com/cdepillabout/stacklock2nix/pull/17).
 
 ## 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,42 @@ this is unlikely to be much of a problem for most users in practice.)
     `stack.yaml.lock` file.  `stacklock2nix` uses the exact version of each package
     from the `stack.yaml.lock` file.
 
+-   **I'm seeing an error about not being able to find a `.json` file.  What is this?**
+
+    When using `stacklock2nix`, sometimes you'll see an error about not being able to
+    find a `PKG.json` or `PKG.cabal` file.  Here's an example of what this looks like:
+
+    ```console
+    $ nix build -L
+    ...
+    all-cabal-hashes-component-happy> cp: cannot stat '/nix/store/bz3lipc0zb8s6cgjvf23mrx7iicgcy8l-source/happy/1.20.1.1/happy.json': No such file or directory
+    ```
+
+    This is an internal error from `haskellPackages.callHackage` (which is used
+    by `stacklock2nix`) saying that your `all-cabal-hashes` is too old.  It is not
+    able to find the package version it is looking for.
+
+    The solution to this is to pass a newer version of `all-cabal-hashes` to
+    `stacklock2nix`:
+
+    ```nix
+    my-haskell-stacklock = final.stacklock2nix {
+      stackYaml = ./stack.yaml;
+      all-cabal-hashes = final.fetchFromGitHub {
+        owner = "commercialhaskell";
+        repo = "all-cabal-hashes";
+        rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
+        sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
+      };
+      ...
+    };
+    ```
+
+    You should be able to go to
+    <https://github.com/commercialhaskell/all-cabal-hashes/tree/hackage> and
+    just pick the latest commit. It is also possible to add this repo as a Nix
+    flake input.
+
 ## Contributions and Where to Get Help
 
 Contributions are highly appreciated.  If there is something you would like to

--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -8,6 +8,26 @@
   # `VersionString` will be a string like `"0.1.2.3"`, but may also be `null`
   # for local packages (since it is sometimes hard to figure out a version for
   # a local package without parsing the .cabal file).
+  #
+  # Example:
+  # ```
+  # args: args // {
+  #   "pango" = version: { pango = final.pango; };
+  # }
+  # ```
+  #
+  # The `args` argument is the default attribute set of arguments that are
+  # specified in this file.  Most people will want to keep them (since they
+  # are generally helpful), but you could throw them all away and define
+  # your own set of arguments, like this:
+  #
+  # ```
+  # _: {
+  #   "cairo" = version: { pango = final.cairo; };
+  #   "pango" = version: { pango = final.pango; };
+  #   "test-framework" = version: { libxml = final.libxml; };
+  # }
+  # ```
   cabal2nixArgsOverrides ? (args: args)
 }:
 

--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -60,6 +60,8 @@
 # Make sure to keep this list in alphabetical order.
 
 cabal2nixArgsOverrides {
+  "cairo" = ver: { cairo = pkgs.cairo; };
+
   "gi-cairo" = ver: { cairo = pkgs.cairo; };
 
   "gi-gdk" = ver: { gtk3 = pkgs.gtk3; };
@@ -85,6 +87,8 @@ cabal2nixArgsOverrides {
   "haskell-gi" = ver: { glib = pkgs.glib; gobject-introspection = pkgs.gobject-introspection; };
 
   "haskell-gi-base" = ver: { glib = pkgs.glib; };
+
+  "pango" = ver: { pango = pkgs.pango; };
 
   # The PSQueue and fingertree-psqueue packages are used in benchmarks, but they are not on Stackage.
   "psqueues" = ver: { fingertree-psqueue = null; PSQueue = null; };

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -796,6 +796,7 @@ in
     devShell
     newPkgSet
     newPkgSetDevShell
+    all-cabal-hashes
     ;
 
   # These are a bunch of internal attributes, used for testing.
@@ -803,7 +804,6 @@ in
   # `.Internal` modules in Haskell.
   _internal = {
     inherit
-      all-cabal-hashes
       fetchCabalFileRevision
       resolverParsed
       snapshotInfo


### PR DESCRIPTION
This PR does a few things:

- Add two readme entries.  One about needing to specify `all-cabal-hashes`.  And another about what to do when you get an `infinite recursion` Nix error.
- Add `all-cabal-hashes` as an official output from `stacklock2nix`.
- Add `cabal2nixArgsForPkg` overrides for the haskell packages `cairo` and `pango`, as brought up by @silky on Matrix.