### PR TITLE
Add localPkgFilter argument to stacklock2nix for filtering local Haskell packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+
+## 2.0.0
+
+*   Add a `localPkgFilter` argument to `stacklock2nix`.  This can be used to
+    filter the sources of local Haskell packages.
+
+    Here's an example of how you might use it:
+
+    ```nix
+    stacklock2nix {
+      stackYaml = ./stack.yaml;
+      localPkgFilter = defaultLocalPkgFilter: pkgName: path: type:
+        if pkgName == "my-example-haskell-lib" && baseNameOf path == "extra-file" then
+          false
+        else
+          defaultLocalPkgFilter path type;
+    }
+    ```
+
+    This is an example of filtering out a file called `extra-file` from the input
+    source of the Haskell package `my-example-haskell-lib`.
+
+    This is a major version bump because if you don't specify the
+    `localPkgFilter` argument to `stacklock2nix`, it defaults to using a filter
+    that filters out the `.stack-work/` directory, as well as directories like
+    `dist-newstyle`.  It also passes input files through the
+    `lib.cleanSourceFilter` function, which filters out `.git/`, as well as a
+    few other types of files.
+
+    While this is technically a major version bump, most users won't be
+    negatively affected by this change.  It is quite likely this won't
+    affect most people.
+
+    Added in [#22](https://github.com/cdepillabout/stacklock2nix/pull/22).
+
 ## 1.3.0
 
 *   Add `all-cabal-hashes` as an output from `stacklock2nix`.  This can be

--- a/my-example-haskell-lib-easy/my-example-haskell-lib/extra-file
+++ b/my-example-haskell-lib-easy/my-example-haskell-lib/extra-file
@@ -1,0 +1,4 @@
+This is an extra file.
+
+You may want to use the `localPkgFilter` argument of `stacklock2nix` to ignore
+extra files like this.

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -277,25 +277,43 @@ let
   #
   # data HaskellPkgLock
   #   = HackageDep { hackage :: String }
-  #   | GitDep { name :: String, git :: String, commit :: String, subdir :: String }
+  #   | GitDep { name :: String, git :: String, commit :: String, version :: String, subdir :: Maybe String }
+  #   | UrlDep { url :: String, name :: String, version :: String, sha256 :: String, subdir :: Maybe String }
   #
-  # In `GitDep`, `subdir` can be left out.
+  # In `GitDep` and `UrlDep`, `subdir` can be left out (which is what the `Maybe`
+  # indicates).  You cannot pass `null` for `subdir`, you must just leave it
+  # out if you don't want it to specify it.
   #
-  # Example:
+  # Example `HackageDep`:
+  #
   # ```
   # extraDepCreateNixHaskPkg
   #   hfinal
   #   { hackage = "cassava-0.5.3.0@sha256:06e6dbc0f3467f3d9823321171adc08d6edc639491cadb0ad33b2dca1e530d29,6083"; }
   # ```
   #
-  # Another Example:
+  # Example `GitDep`:
+  #
   # ```
   # extraDepCreateNixHaskPkg
   #   hfinal
   #   { name = "servant-client";
   #     git = "https://github.com/haskell-servant/servant";
   #     commit = "1fba9dc6048cea6184964032b861b052cd54878c";
+  #     version = "0.19";
   #     subdir = "servant-client";
+  #   }
+  # ```
+  #
+  # Example `UrlDep`:
+  #
+  # ```
+  # extraDepCreateNixHaskPkg
+  #   hfinal
+  #   { name = "pretty-simple";
+  #     url = "https://github.com/cdepillabout/pretty-simple/archive/d8ef1b3c2d913a05515b2d1c4fec0b52d2744434.tar.gz";
+  #     version = "4.1.2.0";
+  #     sha256 = "aba1659b4c133b00b7a28837bcb413672823d72835bcee0f1594e0ba4e2ea4af";
   #   }
   # ```
   extraDepCreateNixHaskPkg = hfinal: haskPkgLock:
@@ -373,7 +391,10 @@ let
   # set.
   #
   # haskPkgLocksToOverlay
-  #  :: [ { hackage :: String } ] -> HaskellPkgSet -> HaskellPkgSet -> HaskellPkgSet
+  #  :: [ HaskellPkgLock ] -> HaskellPkgSet -> HaskellPkgSet -> HaskellPkgSet
+  #
+  # See the documentation for extraDepCreateNixHaskPkg for the definition of
+  # HaskellPkgLock.
   #
   # Example:
   # ```
@@ -407,6 +428,7 @@ let
   #     { name = "servant-client";
   #       git = "https://github.com/haskell-servant/servant";
   #       commit = "1fba9dc6048cea6184964032b861b052cd54878c";
+  #       version = "0.19";
   #       subdir = "servant-client";
   #     }
   #   ]

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -120,12 +120,18 @@
   #   if pkgName == "my-example-haskell-lib" && baseNameOf path == "extra-file" then
   #     false
   #   else
-  #     defaultLocalPkgFilter path type;
+  #     defaultLocalPkgFilter path type
   # ```
   #
   # This example filters out the filed called `extra-file` from the input
   # source for the `my-example-haskell-lib` package.  For all other files,
   # `defaultLocalPkgFilter` is called.
+  #
+  # Here's an example of a filter that doesn't filter out anything:
+  #
+  # ```
+  # defaultLocalPkgFilter: pkgName: path: type: true
+  # ```
   localPkgFilter ?
     defaultLocalPkgFilter: pkgName: path: type: defaultLocalPkgFilter path type
 }:

--- a/test/test-all-cabal-hashes-is-dir.nix
+++ b/test/test-all-cabal-hashes-is-dir.nix
@@ -1,4 +1,5 @@
-{ stacklock2nix
+{ lib
+, stacklock2nix
 , haskell
 , cabal-install
 , fetchFromGitHub
@@ -37,6 +38,18 @@ let
       rev = "80869091dcb9f932c15fe57e30d4d0730c5f87df";
       sha256 = "sha256-LAD3/5qeJWbzfqkcWccMOq0pHBnSkNnvBjWnlLzWFvQ=";
     };
+    # This is an example of using the `locakPkgFilter` argument in order to
+    # filter out extra files that aren't needed.
+    #
+    # TODO: This should also actually test that the resulting derivation doesn't
+    # depend on `extra-file` existing or not existing (since it should be filtered
+    # out).
+    localPkgFilter = defaultLocalPkgFilter: pkgName: path: type:
+      # This filters out the file called `extra-file`
+      if pkgName == "my-example-haskell-lib" && baseNameOf path == "extra-file" then
+        false
+      else
+        defaultLocalPkgFilter path type;
   };
 in
 stacklock.newPkgSet.my-example-haskell-app


### PR DESCRIPTION

This PR adds a `localPkgFilter` function that can be used to filter files when building local Haskell packages.
