### PR TITLE
Fixup related to unordered-containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 3.0.1
+
+*   Fix override with unordered-containers argument, `nothunks`.
+
+    Added in [#26](https://github.com/cdepillabout/stacklock2nix/pull/26).
+
 ## 3.0.0
 
 *   Add some additional filters to the default `localPkgFilter` argument.

--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -103,12 +103,18 @@ cabal2nixArgsOverrides {
 
   "termonad" = ver: { vte_291 = pkgs.vte; gtk3 = pkgs.gtk3; pcre2 = pkgs.pcre2;};
 
-  # unordered-containers uses the Haskell package nothunks in its test-suite,
-  # but nothunks is not in Stackage.  We disable the tests for unordered-containers
-  # in the suggestedOverlay.nix file, but callCabal2Nix is called on it before
-  # suggestedOverlay.nix is applied.  So here we need to just pass in null for
-  # the nothunks dependency, since it won't end up being used.
-  "unordered-containers" = ver: { nothunks = null; };
+  "unordered-containers" = ver:
+    # Starting in unordered-containers-0.2.18.0 (which is in LTS-20),
+    # unordered-containers uses the Haskell package nothunks in its test-suite,
+    # but nothunks is not in Stackage.  We disable the tests for
+    # unordered-containers in the suggestedOverlay.nix file, but callCabal2Nix
+    # is called on it before suggestedOverlay.nix is applied.  So here we need
+    # to just pass in null for the nothunks dependency, since it won't end up
+    # being used.
+    if pkgs.lib.versionAtLeast ver "0.2.18" then
+      { nothunks = null; }
+    else
+      {};
 
   "zlib" = ver: { zlib = pkgs.zlib; };
 }


### PR DESCRIPTION
This PR fixes up a problem related to an unordered-containers override.  The new override in this PR will now work with unordered-containers versions before and after 0.2.18 (while the version in `master` only works with unordered-containers` after 0.2.18).

Should fix at least part of #25