### PR TITLE
Handle old splitmix Haskell package arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 
+## 3.0.2
+
+*   Fix override with splitmix argument, `testu01`.
+
+    Added in [#28](https://github.com/cdepillabout/stacklock2nix/pull/28).
+
+*   A few additional overrides added to
+    `nix/build-support/stacklock2nix/suggestedOverlay.nix` to fix some common
+    problems on Darwin.
+
+    Added in [#28](https://github.com/cdepillabout/stacklock2nix/pull/28).
+
 ## 3.0.1
 
 *   Fix override with unordered-containers argument, `nothunks`.

--- a/my-example-haskell-lib-advanced/flake.lock
+++ b/my-example-haskell-lib-advanced/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669507072,
-        "narHash": "sha256-RQAHgHM7wfgUTWbEjb8Ki43tQUUcwIg1Ra+PNustAVI=",
+        "lastModified": 1686089707,
+        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e6b054555c9b10310543cd213ce7c70bb0cbc5f",
+        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1679031679,
-        "narHash": "sha256-OoPl3gyzkcOFfueMYjN2QH/8yK2GgfyV9Tv0QMQHQi0=",
+        "lastModified": 1686119819,
+        "narHash": "sha256-iNXW6oqley2vOHtYpxwvruueMsrYSfH0KhYP2pZ5oYI=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "0200e4c10aaddc39c77315a09b2acb07fac14551",
+        "rev": "8e027606ac4e59498f74024830f8672188ae7bfa",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-advanced/nix/overlay.nix
+++ b/my-example-haskell-lib-advanced/nix/overlay.nix
@@ -16,6 +16,21 @@ final: prev: {
     #
     # If you are using a very recent Stackage resolver and an old Nixpkgs,
     # it is almost always necessary to override `all-cabal-hashes`.
+    #
+    # WARNING: If you're on a case-insensitive filesystem (like some OSX
+    # filesystems), you may get a hash mismatch when using fetchFromGitHub
+    # to fetch all-cabal-hashes.  As a workaround in that case, you may
+    # want to use fetchurl:
+    #
+    # ```
+    # all-cabal-hashes = final.fetchurl {
+    #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840.tar.gz";
+    #   sha256 = "sha256-vYFfZ77fOcOQpAef6VGXlAZBzTe3rjBSS2dDWQQSPUw=";
+    # };
+    # ```
+    #
+    # You can find more information in:
+    # https://github.com/NixOS/nixpkgs/issues/39308
     all-cabal-hashes = final.fetchFromGitHub {
       owner = "commercialhaskell";
       repo = "all-cabal-hashes";

--- a/my-example-haskell-lib-advanced/nix/overlay.nix
+++ b/my-example-haskell-lib-advanced/nix/overlay.nix
@@ -19,8 +19,8 @@ final: prev: {
     all-cabal-hashes = final.fetchFromGitHub {
       owner = "commercialhaskell";
       repo = "all-cabal-hashes";
-      rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
-      sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
+      rev = "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840";
+      sha256 = "sha256-MLF0Vv2RHai3n7b04JeUchQortm+ikuwSjAzAHWvZJs=";
     };
   };
 

--- a/my-example-haskell-lib-easy/flake.lock
+++ b/my-example-haskell-lib-easy/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669507072,
-        "narHash": "sha256-RQAHgHM7wfgUTWbEjb8Ki43tQUUcwIg1Ra+PNustAVI=",
+        "lastModified": 1686089707,
+        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9e6b054555c9b10310543cd213ce7c70bb0cbc5f",
+        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1679031679,
-        "narHash": "sha256-OoPl3gyzkcOFfueMYjN2QH/8yK2GgfyV9Tv0QMQHQi0=",
+        "lastModified": 1686119819,
+        "narHash": "sha256-iNXW6oqley2vOHtYpxwvruueMsrYSfH0KhYP2pZ5oYI=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "0200e4c10aaddc39c77315a09b2acb07fac14551",
+        "rev": "8e027606ac4e59498f74024830f8672188ae7bfa",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-easy/flake.nix
+++ b/my-example-haskell-lib-easy/flake.nix
@@ -89,6 +89,21 @@
           #
           # If you are using a very recent Stackage resolver and an old Nixpkgs,
           # it is almost always necessary to override `all-cabal-hashes`.
+          #
+          # WARNING: If you're on a case-insensitive filesystem (like some OSX
+          # filesystems), you may get a hash mismatch when using fetchFromGitHub
+          # to fetch all-cabal-hashes.  As a workaround in that case, you may
+          # want to use fetchurl:
+          #
+          # ```
+          # all-cabal-hashes = final.fetchurl {
+          #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840.tar.gz";
+          #   sha256 = "sha256-vYFfZ77fOcOQpAef6VGXlAZBzTe3rjBSS2dDWQQSPUw=";
+          # };
+          # ```
+          #
+          # You can find more information in:
+          # https://github.com/NixOS/nixpkgs/issues/39308
           all-cabal-hashes = final.fetchFromGitHub {
             owner = "commercialhaskell";
             repo = "all-cabal-hashes";

--- a/my-example-haskell-lib-easy/flake.nix
+++ b/my-example-haskell-lib-easy/flake.nix
@@ -92,8 +92,8 @@
           all-cabal-hashes = final.fetchFromGitHub {
             owner = "commercialhaskell";
             repo = "all-cabal-hashes";
-            rev = "9ab160f48cb535719783bc43c0fbf33e6d52fa99";
-            sha256 = "sha256-Hz/xaCoxe4cJBH3h/KIfjzsrEyD915YEVEK8HFR7nO4=";
+            rev = "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840";
+            sha256 = "sha256-MLF0Vv2RHai3n7b04JeUchQortm+ikuwSjAzAHWvZJs=";
           };
         };
 

--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -97,7 +97,15 @@ cabal2nixArgsOverrides {
 
   "secp256k1-haskell" = ver: { secp256k1 = pkgs.secp256k1; };
 
-  "splitmix" = ver: { testu01 = null; };
+  "splitmix" = ver:
+    # Starting in splitmix-0.1.0.4, a system library called testu01 is used in
+    # tests, but it is not available in Nixpkgs.  We disable the tests for
+    # splitmix in the suggestedOverlay.nix file, so it is fine to just pass
+    # this argument as null.
+    if pkgs.lib.versionAtLeast ver "0.1.0.4" then
+      { testu01 = null; }
+    else
+      {};
 
   "test-framework" = ver: { libxml = pkgs.libxml; };
 

--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -102,8 +102,14 @@ cabal2nixArgsOverrides {
     # tests, but it is not available in Nixpkgs.  We disable the tests for
     # splitmix in the suggestedOverlay.nix file, so it is fine to just pass
     # this argument as null.
+    #
+    # However, testu01 is only used on Linux, so we don't need to do anything
+    # if this is not Linux.
     if pkgs.lib.versionAtLeast ver "0.1.0.4" then
-      { testu01 = null; }
+      if pkgs.stdenv.isLinux then
+        { testu01 = null; }
+      else
+        {}
     else
       {};
 

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -168,6 +168,10 @@ hfinal: hprev: with haskell.lib.compose; {
   # Disabling doctests.
   regex-tdfa = overrideCabal { testTarget = "regex-tdfa-unittest"; } hprev.regex-tdfa;
 
+  # the rio test suite calls functions from unliftio that are broken:
+  # https://github.com/fpco/unliftio/issues/87
+  rio = dontCheck hprev.rio;
+
   # https://github.com/ndmitchell/shake/issues/804
   shake = dontCheck hprev.shake;
 
@@ -211,6 +215,10 @@ hfinal: hprev: with haskell.lib.compose; {
 
   # tests don't support musl
   unix-time = dontCheck hprev.unix-time;
+
+  # unliftio test suite has functions that are broken on darwin
+  # https://github.com/fpco/unliftio/issues/87
+  unliftio = dontCheck hprev.unliftio;
 
   # Test suite requires the nothunks library, which isn't on stackage.
   unordered-containers = dontCheck hprev.unordered-containers;

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -105,6 +105,10 @@ hfinal: hprev: with haskell.lib.compose; {
   # Version constraints on tests are too strict.
   haddock-library = dontCheck hprev.haddock-library;
 
+  # Old versions of the happy testsuite will segfault on ARM due to an LLVM bug:
+  # https://github.com/llvm/llvm-project/issues/52844
+  happy = dontCheck hprev.happy;
+
   hashable = dontCheck hprev.hashable;
 
   haskeline = dontCheck hprev.haskeline;


### PR DESCRIPTION
This PR handles the cabal2nix arguments for splitmix older than 0.1.0.4.

Close #27
