### PR TITLE
Update flake.lock to latest version of nixpkgs and stacklock2nix

### DIFF
--- a/my-example-haskell-lib-advanced/flake.lock
+++ b/my-example-haskell-lib-advanced/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686089707,
-        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
+        "lastModified": 1686582075,
+        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
+        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1686119819,
-        "narHash": "sha256-iNXW6oqley2vOHtYpxwvruueMsrYSfH0KhYP2pZ5oYI=",
+        "lastModified": 1686721363,
+        "narHash": "sha256-ZIRCubbKAwuNjMWdeXl9Gs7WaBGa5nQkK8hDXP6NejQ=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "8e027606ac4e59498f74024830f8672188ae7bfa",
+        "rev": "5cf045e262079a8233c6e84725c3471d217254e2",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-easy/flake.lock
+++ b/my-example-haskell-lib-easy/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686089707,
-        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
+        "lastModified": 1686582075,
+        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
+        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1686119819,
-        "narHash": "sha256-iNXW6oqley2vOHtYpxwvruueMsrYSfH0KhYP2pZ5oYI=",
+        "lastModified": 1686721363,
+        "narHash": "sha256-ZIRCubbKAwuNjMWdeXl9Gs7WaBGa5nQkK8hDXP6NejQ=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "8e027606ac4e59498f74024830f8672188ae7bfa",
+        "rev": "5cf045e262079a8233c6e84725c3471d217254e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This update picks up the latest changes that are necessary for building on OSX, including #28.