### PR TITLE
Use flake inputs to fetch `all-cabal-hashes`

### DIFF
--- a/my-example-haskell-lib-easy/flake.lock
+++ b/my-example-haskell-lib-easy/flake.lock
@@ -3,17 +3,17 @@
     "all-cabal-hashes": {
       "flake": false,
       "locked": {
-        "lastModified": 1686227181,
-        "narHash": "sha256-WMkGyt1IFBGQzw4vnCouiiAhPa8BXr7cFM30RZsgvLY=",
+        "lastModified": 1686760018,
+        "narHash": "sha256-ip6G/Et4wBD7Y6FSVHOR3I8ALIPtoUUEmLYQCOZjlEg=",
         "owner": "commercialhaskell",
         "repo": "all-cabal-hashes",
-        "rev": "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840",
+        "rev": "50d9638cef449a0cd59d698d5e8c2d5abccf18a8",
         "type": "github"
       },
       "original": {
         "owner": "commercialhaskell",
+        "ref": "hackage",
         "repo": "all-cabal-hashes",
-        "rev": "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840",
         "type": "github"
       }
     },

--- a/my-example-haskell-lib-easy/flake.lock
+++ b/my-example-haskell-lib-easy/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "all-cabal-hashes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1686227181,
+        "narHash": "sha256-WMkGyt1IFBGQzw4vnCouiiAhPa8BXr7cFM30RZsgvLY=",
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840",
+        "type": "github"
+      },
+      "original": {
+        "owner": "commercialhaskell",
+        "repo": "all-cabal-hashes",
+        "rev": "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1686089707,
@@ -18,17 +35,18 @@
     },
     "root": {
       "inputs": {
+        "all-cabal-hashes": "all-cabal-hashes",
         "nixpkgs": "nixpkgs",
         "stacklock2nix": "stacklock2nix"
       }
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1686119819,
-        "narHash": "sha256-iNXW6oqley2vOHtYpxwvruueMsrYSfH0KhYP2pZ5oYI=",
+        "lastModified": 1686721363,
+        "narHash": "sha256-ZIRCubbKAwuNjMWdeXl9Gs7WaBGa5nQkK8hDXP6NejQ=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "8e027606ac4e59498f74024830f8672188ae7bfa",
+        "rev": "5cf045e262079a8233c6e84725c3471d217254e2",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-easy/flake.nix
+++ b/my-example-haskell-lib-easy/flake.nix
@@ -16,7 +16,6 @@
   # This is a flake reference to Nixpkgs.
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-
   # When creating your own Haskell package set from the stacklock2nix
   # output, you may need to specify a newer all-cabal-hashes.
   #

--- a/my-example-haskell-lib-easy/flake.nix
+++ b/my-example-haskell-lib-easy/flake.nix
@@ -35,7 +35,7 @@
   #
   # $ nix flake lock --update-input all-cabal-hashes
   inputs.all-cabal-hashes = {
-    url = "github:commercialhaskell/all-cabal-hashes?rev=f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840";
+    url = "github:commercialhaskell/all-cabal-hashes/hackage";
     flake = false;
   };
 

--- a/my-example-haskell-lib-easy/flake.nix
+++ b/my-example-haskell-lib-easy/flake.nix
@@ -16,7 +16,31 @@
   # This is a flake reference to Nixpkgs.
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs, stacklock2nix }:
+
+  # When creating your own Haskell package set from the stacklock2nix
+  # output, you may need to specify a newer all-cabal-hashes.
+  #
+  # This is necessary when you are using a Stackage snapshot/resolver or
+  # `extraDeps` in your `stack.yaml` file that is _newer_ than the
+  # `all-cabal-hashes` derivation from the Nixpkgs you are using.
+  #
+  # If you are using the latest nixpkgs-unstable and an old Stackage
+  # resolver, then it is usually not necessary to override
+  # `all-cabal-hashes`.
+  #
+  # If you are using a very recent Stackage resolver and an old Nixpkgs,
+  # it is almost always necessary to override `all-cabal-hashes`.
+  #
+  # Note that if you copy the `./flake.lock` to your own repo, you'll likely
+  # want to update the commit that this all-cabal-hashes reference points to:
+  #
+  # $ nix flake lock --update-input all-cabal-hashes
+  inputs.all-cabal-hashes = {
+    url = "github:commercialhaskell/all-cabal-hashes?rev=f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840";
+    flake = false;
+  };
+
+  outputs = { self, nixpkgs, stacklock2nix, all-cabal-hashes }:
     let
       # System types to support.
       supportedSystems = [
@@ -76,40 +100,7 @@
             #stacklockHaskellPkgSet.some-haskell-lib
           ];
 
-          # When creating your own Haskell package set from the stacklock2nix
-          # output, you may need to specify a newer all-cabal-hashes.
-          #
-          # This is necessary when you are using a Stackage snapshot/resolver or
-          # `extraDeps` in your `stack.yaml` file that is _newer_ than the
-          # `all-cabal-hashes` derivation from the Nixpkgs you are using.
-          #
-          # If you are using the latest nixpkgs-unstable and an old Stackage
-          # resolver, then it is usually not necessary to override
-          # `all-cabal-hashes`.
-          #
-          # If you are using a very recent Stackage resolver and an old Nixpkgs,
-          # it is almost always necessary to override `all-cabal-hashes`.
-          #
-          # WARNING: If you're on a case-insensitive filesystem (like some OSX
-          # filesystems), you may get a hash mismatch when using fetchFromGitHub
-          # to fetch all-cabal-hashes.  As a workaround in that case, you may
-          # want to use fetchurl:
-          #
-          # ```
-          # all-cabal-hashes = final.fetchurl {
-          #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840.tar.gz";
-          #   sha256 = "sha256-vYFfZ77fOcOQpAef6VGXlAZBzTe3rjBSS2dDWQQSPUw=";
-          # };
-          # ```
-          #
-          # You can find more information in:
-          # https://github.com/NixOS/nixpkgs/issues/39308
-          all-cabal-hashes = final.fetchFromGitHub {
-            owner = "commercialhaskell";
-            repo = "all-cabal-hashes";
-            rev = "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840";
-            sha256 = "sha256-MLF0Vv2RHai3n7b04JeUchQortm+ikuwSjAzAHWvZJs=";
-          };
+          inherit all-cabal-hashes;
         };
 
         # One of our local packages.


### PR DESCRIPTION
Adding `all-cabal-hashes` as an input to simplify maintenance tasks. The following command could be used to update the `all-cabal-hashes` input:

```
nix flake lock --input all-cabal-hashes
```

**TODO**

- [ ] Update `my-example-haskell-lib-advanced` example