### PR TITLE
Suggested overrides to fix packages broken by QuickCheck-2.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.0.3
+
+*   A few additional overrides added to
+    `nix/build-support/stacklock2nix/suggestedOverlay.nix` to fix some
+    breakages in test suites
+    [caused by QuickCheck-2.14.3](https://github.com/nick8325/quickcheck/issues/359).
+    QuickCheck-2.14.3 is included in LTS-20.24, so you'll likely need these fixes if
+    you are using LTS-20.24 or later.
+
+    Added in [#31](https://github.com/cdepillabout/stacklock2nix/pull/31).
 
 ## 3.0.2
 

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -33,6 +33,10 @@
 
 hfinal: hprev: with haskell.lib.compose; {
 
+  # Test suite is broken with QuickCheck-2.14.3:
+  # https://github.com/nick8325/quickcheck/issues/359
+  aeson = dontCheck hprev.aeson;
+
   # the testsuite fails because of not finding tsc without some help
   aeson-typescript = overrideCabal (drv: {
     testToolDepends = drv.testToolDepends or [] ++ [ pkgs.nodePackages.typescript ];
@@ -154,6 +158,10 @@ hfinal: hprev: with haskell.lib.compose; {
   # Tests appear to not include all required files
   lsp-test = dontCheck hprev.lsp-test;
 
+  # Test suite is broken with QuickCheck-2.14.3:
+  # https://github.com/nick8325/quickcheck/issues/359
+  math-functions = dontCheck hprev.math-functions;
+
   # Tests seem to make incorrect assumptions about URLs and order of items from Maps.
   mmark = dontCheck hprev.mmark;
 
@@ -185,6 +193,10 @@ hfinal: hprev: with haskell.lib.compose; {
   sourcemap = dontCheck hprev.sourcemap;
 
   splitmix = dontCheck hprev.splitmix;
+
+  # Test suite is broken with QuickCheck-2.14.3:
+  # https://github.com/nick8325/quickcheck/issues/359
+  statistics = dontCheck hprev.statistics;
 
   syb = dontCheck hprev.syb;
 


### PR DESCRIPTION
This PR adds some suggested overrides due to breakage caused by QuickCheck-2.14.3: https://github.com/nick8325/quickcheck/issues/359

This is necessary starting with LTS-20.24, which included QuickCheck-2.14.3.
