### PR TITLE
Add suggestedOverlay override for tz and tzdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## (next)
+
+*   Add build depend on system `tzdata` package for the Haskell `tz` and
+    `tzdata` packages in `nix/build-support/stacklock2nix/suggestedOverlay.nix`.
+    Fixed in [#52](https://github.com/cdepillabout/stacklock2nix/pull/52).
+
 ## 4.0.2
 
 *   Fix a bug where `stacklock2nix` would throw an error if there were

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -225,6 +225,14 @@ hfinal: hprev: with haskell.lib.compose; {
   # Flaky tests: https://github.com/jfischoff/tmp-postgres/issues/274
   tmp-postgres = dontCheck hprev.tmp-postgres;
 
+  # Depends on system tzdata library.
+  # https://github.com/NixOS/nixpkgs/commit/0c2ff42913035c83d56b53aeafd24b39b31d4152
+  tz = addBuildDepends [ pkgs.tzdata ] hprev.tz;
+
+  # Depends on system tzdata library.
+  # https://github.com/NixOS/nixpkgs/commit/0c2ff42913035c83d56b53aeafd24b39b31d4152
+  tzdata = addBuildDepends [ pkgs.tzdata ] hprev.tzdata;
+
   unagi-chan = dontCheck hprev.unagi-chan;
 
   # tests don't support musl


### PR DESCRIPTION
Both these packages require the system tzdata package for its build hooks.

See https://github.com/NixOS/nixpkgs/commit/0c2ff42913035c83d56b53aeafd24b39b31d4152 for more information.

This sort of fixes https://github.com/cdepillabout/stacklock2nix/issues/40.
