### PR TITLE
Use `--stringify` in `remarshal`

### DIFF
--- a/nix/build-support/stacklock2nix/read-yaml.nix
+++ b/nix/build-support/stacklock2nix/read-yaml.nix
@@ -1,5 +1,5 @@
 
-{ runCommand, remarshal }:
+{ lib, remarshal, runCommand }:
 
 # Read a YAML file into a Nix datatype using IFD.
 #
@@ -15,10 +15,21 @@
 path:
 
 let
+  # Starting in remarshal-0.17.0, it added a new `--stringify` CLI flag:
+  # https://github.com/remarshal-project/remarshal/releases/tag/v0.17.0
+  # If you DO NOT pass this flag, then remarshal throws an error when
+  # converting from YAML to JSON if your input YAML file contains a datetime
+  # node.  See https://github.com/cdepillabout/stacklock2nix/pull/55
+  # for more information.
+  remarshal-stringify-arg =
+    if lib.versionAtLeast remarshal.version "0.17.0"
+    then "--stringify"
+    else "";
+
   jsonOutputDrv =
     runCommand
       "from-yaml"
       { nativeBuildInputs = [ remarshal ]; }
-      "remarshal --stringify -if yaml -i \"${path}\" -of json -o \"$out\"";
+      "remarshal ${remarshal-stringify-arg} -if yaml -i \"${path}\" -of json -o \"$out\"";
 in
 builtins.fromJSON (builtins.readFile jsonOutputDrv)

--- a/nix/build-support/stacklock2nix/read-yaml.nix
+++ b/nix/build-support/stacklock2nix/read-yaml.nix
@@ -19,6 +19,6 @@ let
     runCommand
       "from-yaml"
       { nativeBuildInputs = [ remarshal ]; }
-      "remarshal -if yaml -i \"${path}\" -of json -o \"$out\"";
+      "remarshal --stringify -if yaml -i \"${path}\" -of json -o \"$out\"";
 in
 builtins.fromJSON (builtins.readFile jsonOutputDrv)


### PR DESCRIPTION
I've got this error: `Error: Cannot convert data to JSON (Object of type datetime is not JSON serializable)`, coming from `remarshal`. Fixed it in this commit. Fix was tested in local environment