### PR TITLE
feat!(arguments_of_stacklock2nix): Change additionalDevShellNativeBuildInputs to devShellArguments

### DIFF
--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -46,15 +46,13 @@
   additionalHaskellPkgSetOverrides ? hfinal: hprev: {}
 , # Arguments to provide in the devShell.
   #
-  # devShellArguments :: {
-  #   #nativeBuildInputs :: [ Drv ]
-  #   #buildInputs :: [ Drv ]
-  # }
+  # devShellArguments :: AttrSet
   #
   # Example:
   # devShellArguments = {
   #   nativeBuildInputs = stacklockHaskellPkgSet: [ final.stack ];
   #   buildInputs = stacklockHaskellPkgSet: [ final.pango ];
+  #   SOME_ENV = "HI!!";
   # };
   #
   # `devShellArguments` is unused if `baseHaskellPkgSet` is null.
@@ -785,15 +783,13 @@ let
         inherit all-cabal-hashes;
       });
 
+  shellForArguments = packageSet: lib.attrsets.concatMapAttrs (name: value: { ${name} = value; packages = localPkgsSelector; }) devShellArguments;
+
   devShellForPkgSet = packageSet:
     if packageSet == null then
       null
     else
-      packageSet.shellFor {
-        packages = localPkgsSelector;
-        nativeBuildInputs = devShellArguments.nativeBuildInputs packageSet;
-        buildInputs = devShellArguments.buildInputs packageSet;
-      };
+      packageSet.shellFor (shellForArguments packageSet);
 
   # A development shell created by passing all your local packages (from
   # `localPkgsSelector`) to `pkgSet.shellFor`.

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -789,7 +789,7 @@ let
       packages = localPkgsSelector;
       nativeBuildInputs =
         if lib.attrsets.hasAttrByPath ["nativeBuildInputs"] devShellArguments then
-          devShellArguments.nativeBuildInputs packageSet;
+          devShellArguments.nativeBuildInputs packageSet
         else
           null;
 

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -56,7 +56,10 @@
   # };
   #
   # `devShellArguments` is unused if `baseHaskellPkgSet` is null.
-  devShellArguments ? {}
+  devShellArguments ? {
+    nativeBuildInputs = stacklockHaskellPkgSet: [];
+    buildInputs = stacklockHaskellPkgSet: [];
+  }
 , # When creating your own Haskell package set from the stacklock2nix
   # output, you may need to specify a newer all-cabal-hashes.
   #

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -783,7 +783,12 @@ let
         inherit all-cabal-hashes;
       });
 
-  shellForArguments = packageSet: lib.attrsets.concatMapAttrs (name: value: { ${name} = value; packages = localPkgsSelector; }) devShellArguments;
+  shellForArguments = packageSet:
+    devShellArguments // {
+      packages = localPkgsSelector;
+      nativeBuildInputs = devShellArguments.nativeBuildInputs packageSet;
+      buildInputs = devShellArguments.buildInputs packageSet;
+    };
 
   devShellForPkgSet = packageSet:
     if packageSet == null then

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -791,13 +791,13 @@ let
         if lib.attrsets.hasAttrByPath ["nativeBuildInputs"] devShellArguments then
           devShellArguments.nativeBuildInputs packageSet
         else
-          null;
+          [];
 
       buildInputs =
         if lib.attrsets.hasAttrByPath ["buildInputs"] devShellArguments then
           devShellArguments.buildInputs packageSet
         else
-          null;
+          [];
     };
 
   devShellForPkgSet = packageSet:

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -50,6 +50,12 @@
   #
   # `additionalDevShellNativeBuildInputs` is unused if `baseHaskellPkgSet` is null.
   additionalDevShellNativeBuildInputs ? (stacklockHaskellPkgSet: [])
+, # Additional buildInputs to provide in the devShell.
+  #
+  # additionalDevShellBuildInputs :: [ Drv ]
+  #
+  # `additionalDevShellBuildInputs` is unused if `baseHaskellPkgSet` is null.
+  additionalDevShellBuildInputs ? (stacklockHaskellPkgSet: [])
 , # When creating your own Haskell package set from the stacklock2nix
   # output, you may need to specify a newer all-cabal-hashes.
   #
@@ -783,6 +789,7 @@ let
       packageSet.shellFor {
         packages = localPkgsSelector;
         nativeBuildInputs = additionalDevShellNativeBuildInputs packageSet;
+        buildInputs = additionalDevShellBuildInputs packageSet;
       };
 
   # A development shell created by passing all your local packages (from

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -56,10 +56,7 @@
   # };
   #
   # `devShellArguments` is unused if `baseHaskellPkgSet` is null.
-  devShellArguments ? {
-    nativeBuildInputs = stacklockHaskellPkgSet: [];
-    buildInputs = stacklockHaskellPkgSet: [];
-  }
+  devShellArguments ? {}
 , # When creating your own Haskell package set from the stacklock2nix
   # output, you may need to specify a newer all-cabal-hashes.
   #
@@ -787,10 +784,20 @@ let
       });
 
   shellForArguments = packageSet:
-    devShellArguments // {
+    devShellArguments //
+    {
       packages = localPkgsSelector;
-      nativeBuildInputs = devShellArguments.nativeBuildInputs packageSet;
-      buildInputs = devShellArguments.buildInputs packageSet;
+      nativeBuildInputs =
+        if lib.attrsets.hasAttrByPath ["nativeBuildInputs"] devShellArguments then
+          devShellArguments.nativeBuildInputs packageSet;
+        else
+          null;
+
+      buildInputs =
+        if lib.attrsets.hasAttrByPath ["buildInputs"] devShellArguments then
+          devShellArguments.buildInputs packageSet
+        else
+          null;
     };
 
   devShellForPkgSet = packageSet:

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -44,18 +44,21 @@
   #
   # `additionalHaskellPkgSetOverrides` is unused if `baseHaskellPkgSet` is null.
   additionalHaskellPkgSetOverrides ? hfinal: hprev: {}
-, # Additional nativeBuildInputs to provide in the devShell.
+, # Arguments to provide in the devShell.
   #
-  # additionalDevShellNativeBuildInputs :: [ Drv ]
+  # devShellArguments :: {
+  #   #nativeBuildInputs :: [ Drv ]
+  #   #buildInputs :: [ Drv ]
+  # }
   #
-  # `additionalDevShellNativeBuildInputs` is unused if `baseHaskellPkgSet` is null.
-  additionalDevShellNativeBuildInputs ? (stacklockHaskellPkgSet: [])
-, # Additional buildInputs to provide in the devShell.
+  # Example:
+  # devShellArguments = {
+  #   nativeBuildInputs = [ final.stack ];
+  #   buildInputs = [ final.pango ];
+  # };
   #
-  # additionalDevShellBuildInputs :: [ Drv ]
-  #
-  # `additionalDevShellBuildInputs` is unused if `baseHaskellPkgSet` is null.
-  additionalDevShellBuildInputs ? (stacklockHaskellPkgSet: [])
+  # `devShellArguments` is unused if `baseHaskellPkgSet` is null.
+  devShellArguments ? {}
 , # When creating your own Haskell package set from the stacklock2nix
   # output, you may need to specify a newer all-cabal-hashes.
   #
@@ -788,8 +791,8 @@ let
     else
       packageSet.shellFor {
         packages = localPkgsSelector;
-        nativeBuildInputs = additionalDevShellNativeBuildInputs packageSet;
-        buildInputs = additionalDevShellBuildInputs packageSet;
+        nativeBuildInputs = devShellArguments.nativeBuildInputs packageSet;
+        buildInputs = devShellArguments.buildInputs packageSet;
       };
 
   # A development shell created by passing all your local packages (from

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -53,8 +53,8 @@
   #
   # Example:
   # devShellArguments = {
-  #   nativeBuildInputs = [ final.stack ];
-  #   buildInputs = [ final.pango ];
+  #   nativeBuildInputs = stacklockHaskellPkgSet: [ final.stack ];
+  #   buildInputs = stacklockHaskellPkgSet: [ final.pango ];
   # };
   #
   # `devShellArguments` is unused if `baseHaskellPkgSet` is null.

--- a/test/test-default-local-package/default.nix
+++ b/test/test-default-local-package/default.nix
@@ -28,7 +28,7 @@ let
       amazonka-sso = ver: { amazonka-test = null; };
       amazonka-sts = ver: { amazonka-test = null; };
     };
-    additionalDevShellNativeBuildInputs = stacklockHaskellPkgSet: [
+    devShellArguments.nativeBuildInputs = stacklockHaskellPkgSet: [
       cabal-install
     ];
     all-cabal-hashes = fetchFromGitHub {

--- a/test/test-new-package-set.nix
+++ b/test/test-new-package-set.nix
@@ -27,7 +27,7 @@ let
       amazonka-sso = ver: { amazonka-test = null; };
       amazonka-sts = ver: { amazonka-test = null; };
     };
-    additionalDevShellNativeBuildInputs = stacklockHaskellPkgSet: [
+    devShellArguments.nativeBuildInputs = stacklockHaskellPkgSet: [
       cabal-install
     ];
     # XXX: Make sure to keep the call to fetchurl here, since it is partly

--- a/test/test-no-local-packages/default.nix
+++ b/test/test-no-local-packages/default.nix
@@ -28,7 +28,7 @@ let
       amazonka-sso = ver: { amazonka-test = null; };
       amazonka-sts = ver: { amazonka-test = null; };
     };
-    additionalDevShellNativeBuildInputs = stacklockHaskellPkgSet: [
+    devShellArguments.nativeBuildInputs = stacklockHaskellPkgSet: [
       cabal-install
     ];
     all-cabal-hashes = fetchFromGitHub {


### PR DESCRIPTION
# Changes

- Change `additionalDevShellNativeBuildInputs` to `devShellArguments.nativeBuildInputs`
    - `devShellArguments` is an attribute set which contains some value to pass `packageSet.shellFor`. This attrset frequently has `nativeBuildInputs` or `buildInputs`.

# Reasons

- To use `pkg-config`, other C libraries and C headers on `stacklock2nix`

# How to use `devShellArguments`

See my test repo: [test-haskell-header-loading](https://github.com/haruki7049/test-haskell-header-loading)