### PR TITLE
Fix newPkgSet and bump nixpkgs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,45 @@
 
+## 5.0.0
+
+Starting from this version of `stacklock2nix`, it will only be usable with Nixpkgs >= 24.05!
+
+Big changes:
+
+*   Fixes the construction of `newPkgSet`.  See
+    [here](https://github.com/cdepillabout/stacklock2nix/pull/60#issuecomment-2696401882)
+    for more information.
+
+    One big implication of this change is that Nixpkgs before the referenced
+    commit will not be able to be used with stacklock2nix anymore.  So this
+    version of stacklock2nix will only work with Nixpkgs after that commit (so
+    around `>= nixos-24.05`)!
+
+    Fixed in [#62](https://github.com/cdepillabout/stacklock2nix/pull/62).
+    Thanks to [@Mr-Andersen](https://github.com/Mr-Andersen)!
+
+*   Correctly passes `all-cabal-hashes` to `newPkgSet`.
+    Fixed in [#62](https://github.com/cdepillabout/stacklock2nix/pull/62).
+    Thanks to [@Mr-Andersen](https://github.com/Mr-Andersen) for reporting this.
+
+A few other small changes:
+
+*   Mark some additional packages as `dontCheck` in `suggestedOverlay`:
+
+    - cborg
+    - lifted-base
+    - serialise
+    - servant-cassava
+
+    Implemented in [#62](https://github.com/cdepillabout/stacklock2nix/pull/62)
+
+*   Pass `null` as the `pgp-wordlist` argument to `prettyprinter`.
+    `pgp-wordlist` is a test dep, but it is not in stackage.
+
+    Implemented in [#62](https://github.com/cdepillabout/stacklock2nix/pull/62)
+
+    (Tests for `prettyprinter` were disabled in `suggestedOverlay` in
+    https://github.com/cdepillabout/stacklock2nix/pull/59)
+
 ## 4.2.0
 
 *   Add a new `devShellPkgSetModifier` for giving the user a hook to modify the

--- a/my-example-haskell-lib-advanced/flake.lock
+++ b/my-example-haskell-lib-advanced/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "lastModified": 1741037377,
+        "narHash": "sha256-SvtvVKHaUX4Owb+PasySwZsoc5VUeTf1px34BByiOxw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
+        "rev": "02032da4af073d0f6110540c8677f16d4be0117f",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1686721363,
-        "narHash": "sha256-ZIRCubbKAwuNjMWdeXl9Gs7WaBGa5nQkK8hDXP6NejQ=",
+        "lastModified": 1741086198,
+        "narHash": "sha256-Zg5g/6hLulAzuQcgJPh2Od7/nIPhRoO+evFdL9iJpKY=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "5cf045e262079a8233c6e84725c3471d217254e2",
+        "rev": "c6a69ac3e6825af165eeb42e6d5d323214706259",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-advanced/nix/overlay.nix
+++ b/my-example-haskell-lib-advanced/nix/overlay.nix
@@ -24,8 +24,8 @@ final: prev: {
     #
     # ```
     # all-cabal-hashes = final.fetchurl {
-    #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840.tar.gz";
-    #   sha256 = "sha256-vYFfZ77fOcOQpAef6VGXlAZBzTe3rjBSS2dDWQQSPUw=";
+    #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/578b09df5072f21768cfe13edfc3e4c3e41428fc.tar.gz";
+    #   sha256 = "sha256-vYFfZ77fOcOQpAef6VGXlAZBzTe3rjBSS2dDWQQSPPw=";
     # };
     # ```
     #
@@ -34,8 +34,8 @@ final: prev: {
     all-cabal-hashes = final.fetchFromGitHub {
       owner = "commercialhaskell";
       repo = "all-cabal-hashes";
-      rev = "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840";
-      sha256 = "sha256-MLF0Vv2RHai3n7b04JeUchQortm+ikuwSjAzAHWvZJs=";
+      rev = "578b09df5072f21768cfe13edfc3e4c3e41428fc";
+      sha256 = "sha256-fmf4LukOJ2c0bCmNfuN+n2R6bxGhJqag9CBvZQEl3kA=";
     };
   };
 
@@ -45,7 +45,7 @@ final: prev: {
   # This gives you a normal Haskell package set with packages defined by your
   # stack.yaml and Stackage snapshot / resolver.
   my-example-haskell-pkg-set =
-    final.haskell.packages.ghc924.override (oldAttrs: {
+    final.haskell.packages.ghc984.override (oldAttrs: {
 
       # Make sure the package set is created with the same all-cabal-hashes you
       # passed to `stacklock2nix`.
@@ -111,7 +111,7 @@ final: prev: {
         # carefully setup in Nixpkgs so that the tool will compile, and your
         # stacklock2nix Haskell package set will likely contain different
         # versions.
-        final.haskell.packages.ghc924.haskell-language-server
+        final.haskell.packages.ghc984.haskell-language-server
         # Other Haskell tools may need to be taken from the stacklock2nix
         # Haskell package set, and compiled with the example same dependency
         # versions your project depends on.

--- a/my-example-haskell-lib-advanced/stack.yaml
+++ b/my-example-haskell-lib-advanced/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2022-10-18
+resolver: lts-23.10
 # resolver:
 #   url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/30.yaml
 
@@ -44,24 +44,13 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 extra-deps:
 
-  # example dep from hackage
+  # example deps from hackage
   - "unagi-streams-0.2.7"
+  - "microlens-pro-0.2.0.2"
 
   # example git dep
   - git: "https://github.com/haskell-servant/servant-cassava"
-    commit: "f76308b42b9f93a6641c70847cec8ecafbad3abc"
-
-  # example git dep with single subdir
-  - git: "https://github.com/haskell-servant/servant"
-    commit: "1fba9dc6048cea6184964032b861b052cd54878c"
-    subdir: "servant-client"
-
-  # example git dep with multiple subdirs
-  - git: "https://github.com/haskell-servant/servant"
-    commit: "1fba9dc6048cea6184964032b861b052cd54878c"
-    subdirs:
-      - "servant"
-      - "servant-server"
+    commit: "9e27886d7f41023e6aa1429f6f2badf1b3cb5293"
 
   # example of a GitHub dep without subdirs
   - github: cdepillabout/pretty-simple
@@ -69,7 +58,7 @@ extra-deps:
 
   # example of a GitHub dep with multiple subdirs
   - github: brendanhay/amazonka
-    commit: "43e8fb7e6e30e24adef11f66331ae6752642bffd"
+    commit: "fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3"
     subdirs:
       - lib/amazonka
       - lib/amazonka-core

--- a/my-example-haskell-lib-advanced/stack.yaml.lock
+++ b/my-example-haskell-lib-advanced/stack.yaml.lock
@@ -12,55 +12,23 @@ packages:
   original:
     hackage: unagi-streams-0.2.7
 - completed:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    hackage: microlens-pro-0.2.0.2@sha256:2fd14b7f87d6aa76700dabf65fcdda835aa329a4fdd8a44eebdf399e798af7ab,3377
+    pantry-tree:
+      sha256: be8ac1093c45ec46d640c56c06d8826d364ad1243d601e731e37581e8579e9c3
+      size: 430
+  original:
+    hackage: microlens-pro-0.2.0.2
+- completed:
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
     name: servant-cassava
     pantry-tree:
-      sha256: 1e040a08512e69847e2c9a9e313927b4a1864408a32ac935819247291d154ea7
+      sha256: 89ee177e8bce42f1cb466bbab1d8a38ce030e17b52470fff52e863c059a62c99
       size: 652
-    version: 0.10.1
+    version: 0.10.2
   original:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-client
-    pantry-tree:
-      sha256: c37445bd27aa2f7234b3c5ef73533b0952b979f005d38ca5ebfc8230e2712f92
-      size: 1481
-    subdir: servant-client
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-client
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant
-    pantry-tree:
-      sha256: ce0c502681ffbf5cb48f5606e9a9947e4c956b39ed8ce5b1a590dbaeff112dd9
-      size: 2949
-    subdir: servant
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-server
-    pantry-tree:
-      sha256: 2f0df25ed677c6f08aaf1499eec2c82830aedbbe19564d7356ed77cbd49ceeed
-      size: 2727
-    subdir: servant-server
-    version: 0.19.1
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-server
 - completed:
     name: pretty-simple
     pantry-tree:
@@ -75,58 +43,58 @@ packages:
 - completed:
     name: amazonka
     pantry-tree:
-      sha256: f1ba46f355d47bd1494d01b4eb1002c8efdd666639aa3fd0163581409071b7b8
-      size: 1318
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: 5e28046ad2b59a7a2350533070b2f81b0910458490e34008f81027a6e4a5c746
+      size: 1528
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-core
     pantry-tree:
-      sha256: 8707039e4fb7c575fbcd04906e4f541948ed152534da6d3830b9675badb4c71d
-      size: 3192
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: 771ac55bb21369abe765d6622779890c555fdff9912b3d25ac7b3a21bfa92e4d
+      size: 3222
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-sso
     pantry-tree:
-      sha256: e9a165eda0567cdf0581d29d8b1e9fe2df543474d7c70590e04ec1047ebe6d48
-      size: 1869
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: f8897d82072d662605f60dc3d18e921c04bbb337b5d7caaeaece36fc8aee7fb9
+      size: 1817
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/services/amazonka-sso
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/services/amazonka-sso
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-sts
     pantry-tree:
-      sha256: 3a0d4983a363e953e6dc651d1aaa6ca30755a16c01edf63e5104ece7745e3954
-      size: 2932
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: b2a18c0a04c999f9f32e114ad94bf76a89e463dbb16063ebf0899ee28808f898
+      size: 2880
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 snapshots:
 - completed:
-    sha256: 895204e9116cba1f32047525ec5bad7423216587706e5df044c4a7c191a5d8cb
-    size: 644482
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/10/18.yaml
-  original: nightly-2022-10-18
+    sha256: 889b6bffaf21cd509a7c6017703281e77c2f6df0a0908a11c85fa97fcbf11d4e
+    size: 680573
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/10.yaml
+  original: lts-23.10

--- a/my-example-haskell-lib-easy/flake.lock
+++ b/my-example-haskell-lib-easy/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "lastModified": 1741037377,
+        "narHash": "sha256-SvtvVKHaUX4Owb+PasySwZsoc5VUeTf1px34BByiOxw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
+        "rev": "02032da4af073d0f6110540c8677f16d4be0117f",
         "type": "github"
       },
       "original": {
@@ -24,11 +24,11 @@
     },
     "stacklock2nix": {
       "locked": {
-        "lastModified": 1686721363,
-        "narHash": "sha256-ZIRCubbKAwuNjMWdeXl9Gs7WaBGa5nQkK8hDXP6NejQ=",
+        "lastModified": 1741086198,
+        "narHash": "sha256-Zg5g/6hLulAzuQcgJPh2Od7/nIPhRoO+evFdL9iJpKY=",
         "owner": "cdepillabout",
         "repo": "stacklock2nix",
-        "rev": "5cf045e262079a8233c6e84725c3471d217254e2",
+        "rev": "c6a69ac3e6825af165eeb42e6d5d323214706259",
         "type": "github"
       },
       "original": {

--- a/my-example-haskell-lib-easy/flake.nix
+++ b/my-example-haskell-lib-easy/flake.nix
@@ -43,7 +43,7 @@
 
           # The Haskell package set to use as a base.  You should change this
           # based on the compiler version from the resolver in your stack.yaml.
-          baseHaskellPkgSet = final.haskell.packages.ghc924;
+          baseHaskellPkgSet = final.haskell.packages.ghc984;
 
           # Any additional Haskell package overrides you may want to add.
           additionalHaskellPkgSetOverrides = hfinal: hprev: {
@@ -69,7 +69,7 @@
             # carefully setup in Nixpkgs so that the tool will compile, and your
             # stacklock2nix Haskell package set will likely contain different
             # versions.
-            final.haskell.packages.ghc924.haskell-language-server
+            final.haskell.packages.ghc984.haskell-language-server
             # Other Haskell tools may need to be taken from the stacklock2nix
             # Haskell package set, and compiled with the example same dependency
             # versions your project depends on.
@@ -97,8 +97,8 @@
           #
           # ```
           # all-cabal-hashes = final.fetchurl {
-          #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840.tar.gz";
-          #   sha256 = "sha256-vYFfZ77fOcOQpAef6VGXlAZBzTe3rjBSS2dDWQQSPUw=";
+          #   url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/578b09df5072f21768cfe13edfc3e4c3e41428fc.tar.gz";
+          #   sha256 = "sha256-vYFfZ77fOcOQpAef6VGXlAZBzTe3rjBSS2dDWQQSPUU=";
           # };
           # ```
           #
@@ -107,8 +107,8 @@
           all-cabal-hashes = final.fetchFromGitHub {
             owner = "commercialhaskell";
             repo = "all-cabal-hashes";
-            rev = "f3f41d1f11f40be4a0eb6d9fcc3fe5ff62c0f840";
-            sha256 = "sha256-MLF0Vv2RHai3n7b04JeUchQortm+ikuwSjAzAHWvZJs=";
+            rev = "578b09df5072f21768cfe13edfc3e4c3e41428fc";
+            sha256 = "sha256-fmf4LukOJ2c0bCmNfuN+n2R6bxGhJqag9CBvZQEl3kA=";
           };
         };
 

--- a/my-example-haskell-lib-easy/stack.yaml
+++ b/my-example-haskell-lib-easy/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2022-10-18
+resolver: lts-23.10
 # resolver:
 #   url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/30.yaml
 
@@ -49,19 +49,7 @@ extra-deps:
 
   # example git dep
   - git: https://github.com/haskell-servant/servant-cassava
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
-
-  # example git dep with single subdir
-  - git: https://github.com/haskell-servant/servant
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    subdir: servant-client
-
-  # example git dep with multiple subdirs
-  - git: https://github.com/haskell-servant/servant
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    subdirs:
-      - servant
-      - servant-server
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/my-example-haskell-lib-easy/stack.yaml.lock
+++ b/my-example-haskell-lib-easy/stack.yaml.lock
@@ -12,58 +12,19 @@ packages:
   original:
     hackage: unagi-streams-0.2.7
 - completed:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
     name: servant-cassava
     pantry-tree:
-      sha256: 1e040a08512e69847e2c9a9e313927b4a1864408a32ac935819247291d154ea7
+      sha256: 89ee177e8bce42f1cb466bbab1d8a38ce030e17b52470fff52e863c059a62c99
       size: 652
-    version: 0.10.1
+    version: 0.10.2
   original:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-client
-    pantry-tree:
-      sha256: c37445bd27aa2f7234b3c5ef73533b0952b979f005d38ca5ebfc8230e2712f92
-      size: 1481
-    subdir: servant-client
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-client
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant
-    pantry-tree:
-      sha256: ce0c502681ffbf5cb48f5606e9a9947e4c956b39ed8ce5b1a590dbaeff112dd9
-      size: 2949
-    subdir: servant
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-server
-    pantry-tree:
-      sha256: 2f0df25ed677c6f08aaf1499eec2c82830aedbbe19564d7356ed77cbd49ceeed
-      size: 2727
-    subdir: servant-server
-    version: 0.19.1
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-server
 snapshots:
 - completed:
-    sha256: 895204e9116cba1f32047525ec5bad7423216587706e5df044c4a7c191a5d8cb
-    size: 644482
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/10/18.yaml
-  original: nightly-2022-10-18
+    sha256: 889b6bffaf21cd509a7c6017703281e77c2f6df0a0908a11c85fa97fcbf11d4e
+    size: 680573
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/10.yaml
+  original: lts-23.10

--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -92,6 +92,11 @@ cabal2nixArgsOverrides {
 
   "pango" = ver: { pango = pkgs.pango; };
 
+  # This requires the Haskell package pgp-wordlist as a test dependency, but it
+  # is not in Stackage. Tests are disabled in suggestedOverlay.nix, so there
+  # should be no problem with marking this as null.
+  "prettyprinter" = ver: { pgp-wordlist = null; };
+
   "psqueues" = ver:
     if pkgs.lib.versionAtLeast ver "0.2.8.0" then
       # The PSQueue package is used in benchmarks, but it is not on Stackage.

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -967,7 +967,7 @@ let
             additionalHaskellPkgSetOverrides
           ];
 
-          nonHackagePackages = _: _: {};
+          nonHackagePackages = _: _: _: {};
           configurationCommon = _: _: _: {};
           configurationNix = _: _: _: {};
           configurationArm = _: _: _: {};

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -945,7 +945,7 @@ let
       null
     else
       let
-        haskPkgSet = callPackage (nixpkgsPath + "/pkgs/development/haskell-modules") {
+        haskPkgSet = callPackage (nixpkgsPath + "/pkgs/development/haskell-modules") ({
           haskellLib = haskell.lib.compose;
 
           # TODO: Is it okay to use a completely different package set as the
@@ -972,7 +972,10 @@ let
           configurationNix = _: _: _: {};
           configurationArm = _: _: _: {};
           configurationDarwin = _: _: _: {};
-        };
+        } //
+        lib.optionalAttrs (all-cabal-hashes != null) {
+          inherit all-cabal-hashes;
+        });
       in haskPkgSet;
 
   # Same as `devShell`, but based on `newPkgSet`.

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -173,6 +173,9 @@ hfinal: hprev: with haskell.lib.compose; {
   # Tests try to access internet.
   js-jquery = dontCheck hprev.js-jquery;
 
+  # Tests require versions of deps not in stackage.
+  lifted-base = dontCheck hprev.lifted-base;
+
   logging-facade = dontCheck hprev.logging-facade;
 
   logict = dontCheck hprev.logict;

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -215,6 +215,9 @@ hfinal: hprev: with haskell.lib.compose; {
   # https://github.com/fpco/unliftio/issues/87
   rio = dontCheck hprev.rio;
 
+  # Tests require version of tasty-quickcheck not in stackage
+  serialise = dontCheck hprev.serialise;
+
   # Tests try using warp, but require a version not in stackage
   servant-cassava = dontCheck hprev.servant-cassava;
 

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -212,6 +212,9 @@ hfinal: hprev: with haskell.lib.compose; {
   # https://github.com/fpco/unliftio/issues/87
   rio = dontCheck hprev.rio;
 
+  # Tests try using warp, but require a version not in stackage
+  servant-cassava = dontCheck hprev.servant-cassava;
+
   # Tests don't build
   servant-openapi3 = dontCheck hprev.servant-openapi3;
 

--- a/nix/build-support/stacklock2nix/suggestedOverlay.nix
+++ b/nix/build-support/stacklock2nix/suggestedOverlay.nix
@@ -68,6 +68,9 @@ hfinal: hprev: with haskell.lib.compose; {
   # Tests don't include all necessary files.
   c2hs = dontCheck hprev.c2hs;
 
+  # Tests require too-strict version of deps.
+  cborg = dontCheck hprev.cborg;
+
   clock = dontCheck hprev.clock;
 
   colour = dontCheck hprev.colour;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,7 +9,7 @@
 # Within this nix-repl, you have access to everything defined in ./overlay.nix.
 
 let
-  flake-lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+  flake-lock = builtins.fromJSON (builtins.readFile ../my-example-haskell-lib-easy/flake.lock);
 
   nixpkgs-src = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/${flake-lock.nodes.nixpkgs.locked.rev}.tar.gz";

--- a/test/test-all-cabal-hashes-is-dir.nix
+++ b/test/test-all-cabal-hashes-is-dir.nix
@@ -10,7 +10,7 @@ let
 
   stacklock = stacklock2nix {
     stackYaml = ../my-example-haskell-lib-easy/stack.yaml;
-    baseHaskellPkgSet = haskell.packages.ghc924;
+    baseHaskellPkgSet = haskell.packages.ghc984;
     additionalHaskellPkgSetOverrides = hfinal: hprev: {
       # The servant-cassava.cabal file is malformed on GitHub:
       # https://github.com/haskell-servant/servant-cassava/pull/29
@@ -35,8 +35,8 @@ let
     all-cabal-hashes = fetchFromGitHub {
       owner = "commercialhaskell";
       repo = "all-cabal-hashes";
-      rev = "80869091dcb9f932c15fe57e30d4d0730c5f87df";
-      sha256 = "sha256-LAD3/5qeJWbzfqkcWccMOq0pHBnSkNnvBjWnlLzWFvQ=";
+      rev = "578b09df5072f21768cfe13edfc3e4c3e41428fc";
+      sha256 = "sha256-fmf4LukOJ2c0bCmNfuN+n2R6bxGhJqag9CBvZQEl3kA=";
     };
     # This is an example of using the `locakPkgFilter` argument in order to
     # filter out extra files that aren't needed.

--- a/test/test-default-local-package/default.nix
+++ b/test/test-default-local-package/default.nix
@@ -10,7 +10,7 @@ let
 
   stacklock = stacklock2nix {
     stackYaml = ./stack.yaml;
-    baseHaskellPkgSet = haskell.packages.ghc924;
+    baseHaskellPkgSet = haskell.packages.ghc984;
     additionalHaskellPkgSetOverrides = hfinal: hprev: {
       # The servant-cassava.cabal file is malformed on GitHub:
       # https://github.com/haskell-servant/servant-cassava/pull/29
@@ -34,8 +34,8 @@ let
     all-cabal-hashes = fetchFromGitHub {
       owner = "commercialhaskell";
       repo = "all-cabal-hashes";
-      rev = "80869091dcb9f932c15fe57e30d4d0730c5f87df";
-      sha256 = "sha256-LAD3/5qeJWbzfqkcWccMOq0pHBnSkNnvBjWnlLzWFvQ=";
+      rev = "578b09df5072f21768cfe13edfc3e4c3e41428fc";
+      sha256 = "sha256-fmf4LukOJ2c0bCmNfuN+n2R6bxGhJqag9CBvZQEl3kA=";
     };
   };
 in

--- a/test/test-default-local-package/stack.yaml
+++ b/test/test-default-local-package/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-10-18
+resolver: lts-23.10
 
 # This is a test that stacklock2nix works even if the top-level `packages` key
 # is not specified.  In this case, `stack` defaults to having a single package
@@ -6,25 +6,13 @@ resolver: nightly-2022-10-18
 # packages: ["."]
 
 extra-deps:
-
-  # example dep from hackage
+  # example deps from hackage
   - "unagi-streams-0.2.7"
+  - "microlens-pro-0.2.0.2"
 
   # example git dep
   - git: "https://github.com/haskell-servant/servant-cassava"
-    commit: "f76308b42b9f93a6641c70847cec8ecafbad3abc"
-
-  # example git dep with single subdir
-  - git: "https://github.com/haskell-servant/servant"
-    commit: "1fba9dc6048cea6184964032b861b052cd54878c"
-    subdir: "servant-client"
-
-  # example git dep with multiple subdirs
-  - git: "https://github.com/haskell-servant/servant"
-    commit: "1fba9dc6048cea6184964032b861b052cd54878c"
-    subdirs:
-      - "servant"
-      - "servant-server"
+    commit: "9e27886d7f41023e6aa1429f6f2badf1b3cb5293"
 
   # example of a GitHub dep without subdirs
   - github: cdepillabout/pretty-simple
@@ -32,7 +20,7 @@ extra-deps:
 
   # example of a GitHub dep with multiple subdirs
   - github: brendanhay/amazonka
-    commit: "43e8fb7e6e30e24adef11f66331ae6752642bffd"
+    commit: "fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3"
     subdirs:
       - lib/amazonka
       - lib/amazonka-core

--- a/test/test-default-local-package/stack.yaml.lock
+++ b/test/test-default-local-package/stack.yaml.lock
@@ -12,55 +12,23 @@ packages:
   original:
     hackage: unagi-streams-0.2.7
 - completed:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    hackage: microlens-pro-0.2.0.2@sha256:2fd14b7f87d6aa76700dabf65fcdda835aa329a4fdd8a44eebdf399e798af7ab,3377
+    pantry-tree:
+      sha256: be8ac1093c45ec46d640c56c06d8826d364ad1243d601e731e37581e8579e9c3
+      size: 430
+  original:
+    hackage: microlens-pro-0.2.0.2
+- completed:
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
     name: servant-cassava
     pantry-tree:
-      sha256: 1e040a08512e69847e2c9a9e313927b4a1864408a32ac935819247291d154ea7
+      sha256: 89ee177e8bce42f1cb466bbab1d8a38ce030e17b52470fff52e863c059a62c99
       size: 652
-    version: 0.10.1
+    version: 0.10.2
   original:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-client
-    pantry-tree:
-      sha256: c37445bd27aa2f7234b3c5ef73533b0952b979f005d38ca5ebfc8230e2712f92
-      size: 1481
-    subdir: servant-client
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-client
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant
-    pantry-tree:
-      sha256: ce0c502681ffbf5cb48f5606e9a9947e4c956b39ed8ce5b1a590dbaeff112dd9
-      size: 2949
-    subdir: servant
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-server
-    pantry-tree:
-      sha256: 2f0df25ed677c6f08aaf1499eec2c82830aedbbe19564d7356ed77cbd49ceeed
-      size: 2727
-    subdir: servant-server
-    version: 0.19.1
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-server
 - completed:
     name: pretty-simple
     pantry-tree:
@@ -75,58 +43,58 @@ packages:
 - completed:
     name: amazonka
     pantry-tree:
-      sha256: f1ba46f355d47bd1494d01b4eb1002c8efdd666639aa3fd0163581409071b7b8
-      size: 1318
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: 5e28046ad2b59a7a2350533070b2f81b0910458490e34008f81027a6e4a5c746
+      size: 1528
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-core
     pantry-tree:
-      sha256: 8707039e4fb7c575fbcd04906e4f541948ed152534da6d3830b9675badb4c71d
-      size: 3192
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: 771ac55bb21369abe765d6622779890c555fdff9912b3d25ac7b3a21bfa92e4d
+      size: 3222
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-sso
     pantry-tree:
-      sha256: e9a165eda0567cdf0581d29d8b1e9fe2df543474d7c70590e04ec1047ebe6d48
-      size: 1869
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: f8897d82072d662605f60dc3d18e921c04bbb337b5d7caaeaece36fc8aee7fb9
+      size: 1817
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/services/amazonka-sso
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/services/amazonka-sso
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-sts
     pantry-tree:
-      sha256: 3a0d4983a363e953e6dc651d1aaa6ca30755a16c01edf63e5104ece7745e3954
-      size: 2932
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: b2a18c0a04c999f9f32e114ad94bf76a89e463dbb16063ebf0899ee28808f898
+      size: 2880
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 snapshots:
 - completed:
-    sha256: 895204e9116cba1f32047525ec5bad7423216587706e5df044c4a7c191a5d8cb
-    size: 644482
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/10/18.yaml
-  original: nightly-2022-10-18
+    sha256: 889b6bffaf21cd509a7c6017703281e77c2f6df0a0908a11c85fa97fcbf11d4e
+    size: 680573
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/10.yaml
+  original: lts-23.10

--- a/test/test-new-package-set.nix
+++ b/test/test-new-package-set.nix
@@ -9,7 +9,7 @@ let
 
   stacklock = stacklock2nix {
     stackYaml = ../my-example-haskell-lib-advanced/stack.yaml;
-    baseHaskellPkgSet = haskell.packages.ghc924;
+    baseHaskellPkgSet = haskell.packages.ghc984;
     additionalHaskellPkgSetOverrides = hfinal: hprev: {
       # The servant-cassava.cabal file is malformed on GitHub:
       # https://github.com/haskell-servant/servant-cassava/pull/29
@@ -36,8 +36,8 @@ let
     # being a tarball. (fetchurl makes the output derivation a tarball.)
     all-cabal-hashes = fetchurl {
       name = "all-cabal-hashes";
-      url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/80869091dcb9f932c15fe57e30d4d0730c5f87df.tar.gz";
-      sha256 = "sha256-FI1Z1zMPnOXRBAPJiSI5VIyH6JkOuY9Cu1qdq1vwjK0=";
+      url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/578b09df5072f21768cfe13edfc3e4c3e41428fc.tar.gz";
+      sha256 = "sha256-z9GGg21QObZHsK//45zGshdbjsJh3wsw9Oo0R1TYqT8=";
     };
   };
 in

--- a/test/test-no-local-packages/default.nix
+++ b/test/test-no-local-packages/default.nix
@@ -10,7 +10,7 @@ let
 
   stacklock = stacklock2nix {
     stackYaml = ./stack.yaml;
-    baseHaskellPkgSet = haskell.packages.ghc924;
+    baseHaskellPkgSet = haskell.packages.ghc984;
     additionalHaskellPkgSetOverrides = hfinal: hprev: {
       # The servant-cassava.cabal file is malformed on GitHub:
       # https://github.com/haskell-servant/servant-cassava/pull/29
@@ -34,8 +34,8 @@ let
     all-cabal-hashes = fetchFromGitHub {
       owner = "commercialhaskell";
       repo = "all-cabal-hashes";
-      rev = "80869091dcb9f932c15fe57e30d4d0730c5f87df";
-      sha256 = "sha256-LAD3/5qeJWbzfqkcWccMOq0pHBnSkNnvBjWnlLzWFvQ=";
+      rev = "578b09df5072f21768cfe13edfc3e4c3e41428fc";
+      sha256 = "sha256-fmf4LukOJ2c0bCmNfuN+n2R6bxGhJqag9CBvZQEl3kA=";
     };
   };
 in

--- a/test/test-no-local-packages/stack.yaml
+++ b/test/test-no-local-packages/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-10-18
+resolver: lts-23.10
 
 # This is a test that stacklock2nix works even if there are no local packages
 # defined in the stack.yaml file, so we want to make sure we have no local
@@ -6,25 +6,13 @@ resolver: nightly-2022-10-18
 packages: []
 
 extra-deps:
-
-  # example dep from hackage
+  # example deps from hackage
   - "unagi-streams-0.2.7"
+  - "microlens-pro-0.2.0.2"
 
   # example git dep
   - git: "https://github.com/haskell-servant/servant-cassava"
-    commit: "f76308b42b9f93a6641c70847cec8ecafbad3abc"
-
-  # example git dep with single subdir
-  - git: "https://github.com/haskell-servant/servant"
-    commit: "1fba9dc6048cea6184964032b861b052cd54878c"
-    subdir: "servant-client"
-
-  # example git dep with multiple subdirs
-  - git: "https://github.com/haskell-servant/servant"
-    commit: "1fba9dc6048cea6184964032b861b052cd54878c"
-    subdirs:
-      - "servant"
-      - "servant-server"
+    commit: "9e27886d7f41023e6aa1429f6f2badf1b3cb5293"
 
   # example of a GitHub dep without subdirs
   - github: cdepillabout/pretty-simple
@@ -32,7 +20,7 @@ extra-deps:
 
   # example of a GitHub dep with multiple subdirs
   - github: brendanhay/amazonka
-    commit: "43e8fb7e6e30e24adef11f66331ae6752642bffd"
+    commit: "fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3"
     subdirs:
       - lib/amazonka
       - lib/amazonka-core

--- a/test/test-no-local-packages/stack.yaml.lock
+++ b/test/test-no-local-packages/stack.yaml.lock
@@ -12,55 +12,23 @@ packages:
   original:
     hackage: unagi-streams-0.2.7
 - completed:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    hackage: microlens-pro-0.2.0.2@sha256:2fd14b7f87d6aa76700dabf65fcdda835aa329a4fdd8a44eebdf399e798af7ab,3377
+    pantry-tree:
+      sha256: be8ac1093c45ec46d640c56c06d8826d364ad1243d601e731e37581e8579e9c3
+      size: 430
+  original:
+    hackage: microlens-pro-0.2.0.2
+- completed:
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
     name: servant-cassava
     pantry-tree:
-      sha256: 1e040a08512e69847e2c9a9e313927b4a1864408a32ac935819247291d154ea7
+      sha256: 89ee177e8bce42f1cb466bbab1d8a38ce030e17b52470fff52e863c059a62c99
       size: 652
-    version: 0.10.1
+    version: 0.10.2
   original:
-    commit: f76308b42b9f93a6641c70847cec8ecafbad3abc
+    commit: 9e27886d7f41023e6aa1429f6f2badf1b3cb5293
     git: https://github.com/haskell-servant/servant-cassava
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-client
-    pantry-tree:
-      sha256: c37445bd27aa2f7234b3c5ef73533b0952b979f005d38ca5ebfc8230e2712f92
-      size: 1481
-    subdir: servant-client
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-client
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant
-    pantry-tree:
-      sha256: ce0c502681ffbf5cb48f5606e9a9947e4c956b39ed8ce5b1a590dbaeff112dd9
-      size: 2949
-    subdir: servant
-    version: '0.19'
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant
-- completed:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    name: servant-server
-    pantry-tree:
-      sha256: 2f0df25ed677c6f08aaf1499eec2c82830aedbbe19564d7356ed77cbd49ceeed
-      size: 2727
-    subdir: servant-server
-    version: 0.19.1
-  original:
-    commit: 1fba9dc6048cea6184964032b861b052cd54878c
-    git: https://github.com/haskell-servant/servant
-    subdir: servant-server
 - completed:
     name: pretty-simple
     pantry-tree:
@@ -75,58 +43,58 @@ packages:
 - completed:
     name: amazonka
     pantry-tree:
-      sha256: f1ba46f355d47bd1494d01b4eb1002c8efdd666639aa3fd0163581409071b7b8
-      size: 1318
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: 5e28046ad2b59a7a2350533070b2f81b0910458490e34008f81027a6e4a5c746
+      size: 1528
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/amazonka
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-core
     pantry-tree:
-      sha256: 8707039e4fb7c575fbcd04906e4f541948ed152534da6d3830b9675badb4c71d
-      size: 3192
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: 771ac55bb21369abe765d6622779890c555fdff9912b3d25ac7b3a21bfa92e4d
+      size: 3222
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/amazonka-core
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-sso
     pantry-tree:
-      sha256: e9a165eda0567cdf0581d29d8b1e9fe2df543474d7c70590e04ec1047ebe6d48
-      size: 1869
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: f8897d82072d662605f60dc3d18e921c04bbb337b5d7caaeaece36fc8aee7fb9
+      size: 1817
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/services/amazonka-sso
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/services/amazonka-sso
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 - completed:
     name: amazonka-sts
     pantry-tree:
-      sha256: 3a0d4983a363e953e6dc651d1aaa6ca30755a16c01edf63e5104ece7745e3954
-      size: 2932
-    sha256: 3cc2cdb4add25e6ef36c5124301387039b2f71fb7a809732cfce182b830787b1
-    size: 30018929
+      sha256: b2a18c0a04c999f9f32e114ad94bf76a89e463dbb16063ebf0899ee28808f898
+      size: 2880
+    sha256: 1ef33a37b2526a78cdc49c329dce024d6aa8a95d30c3ccc66d7fdbd197346b35
+    size: 34734902
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
     version: '2.0'
   original:
     subdir: lib/services/amazonka-sts
-    url: https://github.com/brendanhay/amazonka/archive/43e8fb7e6e30e24adef11f66331ae6752642bffd.tar.gz
+    url: https://github.com/brendanhay/amazonka/archive/fbc91ee7d0434b7614e3fe8de993348a4c6ca7a3.tar.gz
 snapshots:
 - completed:
-    sha256: 895204e9116cba1f32047525ec5bad7423216587706e5df044c4a7c191a5d8cb
-    size: 644482
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2022/10/18.yaml
-  original: nightly-2022-10-18
+    sha256: 889b6bffaf21cd509a7c6017703281e77c2f6df0a0908a11c85fa97fcbf11d4e
+    size: 680573
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/10.yaml
+  original: lts-23.10


### PR DESCRIPTION
This PR is a continuation of https://github.com/cdepillabout/stacklock2nix/pull/60.

This PR has two big changes:

- Fixes `newPkgSet`.  See https://github.com/cdepillabout/stacklock2nix/pull/60#issuecomment-2696401882 for more information.  This change means that Nixpkgs before the referenced commit will not be able to be used with stacklock2nix anymore.  So the next version of stacklock2nix will only work with Nixpkgs after that commit (so `>= nixos-24.05`).  6d12a56d09cdf1
- Correctly passes `all-cabal-hashes` to `newPkgSet`.  This resolves #61. 57ea2606ba1

This PR also does the following which end users may notice:

- Add cborg as dontCheck to the suggestedOverlay
- Pass `null` as the `pgp-wordlist` argument to `prettyprinter`.  `pgp-wordlist` is a test dep, but it is not in stackage.  Tests for `prettyprinter` have been disabled in `suggestedOverlay` in https://github.com/cdepillabout/stacklock2nix/pull/59.
- Add lifted-base as dontCheck to the suggestedOverlay
- Add serialise as dontChec to the suggestedOverlay
- Add servant-cassava as dontCheck to the suggestedOverlay

This PR also has the following internal changes that do not affect end users:

- Bump the examples and tests for stacklock2nix to LTS-23 (GHC-9.8).