### PR TITLE
Add some passthru values for Haskell derivations created by stacklock2nix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,54 @@ Big changes:
 
 A few other small changes:
 
+*   Expose some additional `passthru` values on Haskell derivations generated
+    by stacklock2nix.
+
+    All Haskell derivations generated with `stacklock2nix` now have a
+    `passthru.stacklock2nix` key, which is an attrset filled with the
+    following keys.  All keys have a `Bool` value:
+
+    -   `is-local-pkg`: Is this a local package defined in `stack.yaml`?
+    -   `is-extra-dep`: Is this an `extra-dep` defined in `stack.yaml`?
+    -   `is-hackage-dep`: Is this a dep from Hackage?
+    -   `is-git-dep`: Is this a dep from Git?
+    -   `is-url-dep`: Is this a dep from a URL?
+
+    This can be used in your own overlays.  For instance, if you want to
+    apply an overlay to the Haskell package set produced by stacklock2nix
+    that disables tests ONLY for local Haskell packages, you could write
+    the overlay like the following:
+
+    ```nix
+    hfinal: hprev:
+      lib.mapAttrs
+        ( name: drv:
+            if lib.attrByPath [ "passthru" "stacklock2nix" "is-local-pkg" ] false drv then
+              modifierFunc drv
+            else
+              drv
+        )
+        hprev
+    ```
+
+    Added in [#63](https://github.com/cdepillabout/stacklock2nix/pull/63)
+
+    See the tests in that PR for some more examples of how you might want to
+    use this.
+
+*   Expose some additional `passthru` values on the Haskell dev shell generated
+    by stacklock2nix.
+
+    The dev shells generated with `stacklock2nix` now have a
+    `passthru.stacklock2nix` key, which is an attrset filled with the
+    following keys and values:
+
+    -   `dev-shell-pkg-set`: The Haskell package set used to generate this dev shell.
+        This is mainly useful in conjunction with the `devShellPkgSetModifier`, in order
+        to inspect the final package set produced after applying `devShellPkgSetModifier`.
+    -   `shell-for-args`: The passed to `shellFor` in order to produce the dev shell.
+        This is an attrset.
+
 *   Mark some additional packages as `dontCheck` in `suggestedOverlay`:
 
     - cborg

--- a/test/nixpkgs.nix
+++ b/test/nixpkgs.nix
@@ -24,6 +24,8 @@ let
         new-package-set = final.callPackage ./test-new-package-set.nix {};
 
         # This tests that all-cabal-hashes works correctly as a directory (not a tarball).
+        #
+        # This also tests that our stacklock2nix-specific passthru values are working.
         all-cabal-hashes-is-dir = final.callPackage ./test-all-cabal-hashes-is-dir.nix {};
 
         # This test that a stack.yaml with no local packages defined is still

--- a/test/test-all-cabal-hashes-is-dir.nix
+++ b/test/test-all-cabal-hashes-is-dir.nix
@@ -52,4 +52,43 @@ let
         defaultLocalPkgFilter path type;
   };
 in
+
+# Check that our additional passthru values are working. We expect that local
+# packages have is-local-pkg set to true, and all other values set to false.
+assert stacklock.newPkgSet.my-example-haskell-lib.passthru.stacklock2nix.is-local-pkg;
+assert !stacklock.newPkgSet.my-example-haskell-lib.passthru.stacklock2nix.is-extra-dep;
+assert !stacklock.newPkgSet.my-example-haskell-lib.passthru.stacklock2nix.is-hackage-dep;
+assert !stacklock.newPkgSet.my-example-haskell-lib.passthru.stacklock2nix.is-git-dep;
+assert !stacklock.newPkgSet.my-example-haskell-lib.passthru.stacklock2nix.is-url-dep;
+
+# We expect that unagi-streams is Hackage extra-dep.
+assert !stacklock.newPkgSet.unagi-streams.passthru.stacklock2nix.is-local-pkg;
+assert stacklock.newPkgSet.unagi-streams.passthru.stacklock2nix.is-extra-dep;
+assert stacklock.newPkgSet.unagi-streams.passthru.stacklock2nix.is-hackage-dep;
+assert !stacklock.newPkgSet.unagi-streams.passthru.stacklock2nix.is-git-dep;
+assert !stacklock.newPkgSet.unagi-streams.passthru.stacklock2nix.is-url-dep;
+
+# We expect that servant-cassava is a Git extra-dep.
+assert !stacklock.newPkgSet.servant-cassava.passthru.stacklock2nix.is-local-pkg;
+assert stacklock.newPkgSet.servant-cassava.passthru.stacklock2nix.is-extra-dep;
+assert !stacklock.newPkgSet.servant-cassava.passthru.stacklock2nix.is-hackage-dep;
+assert stacklock.newPkgSet.servant-cassava.passthru.stacklock2nix.is-git-dep;
+assert !stacklock.newPkgSet.servant-cassava.passthru.stacklock2nix.is-url-dep;
+
+# TODO: Add a similar test for a URL extra-dep.
+
+# We expect that other packages from Stackage are Hackage deps, but not extra deps.
+# For example, aeson.
+assert !stacklock.newPkgSet.aeson.passthru.stacklock2nix.is-local-pkg;
+assert !stacklock.newPkgSet.aeson.passthru.stacklock2nix.is-extra-dep;
+assert stacklock.newPkgSet.aeson.passthru.stacklock2nix.is-hackage-dep;
+assert !stacklock.newPkgSet.aeson.passthru.stacklock2nix.is-git-dep;
+assert !stacklock.newPkgSet.aeson.passthru.stacklock2nix.is-url-dep;
+
+# We expect that packages not included in Stackage, but from Nixpkgs (from Hackage) don't
+# have any of our stacklock2nix passthru values.
+#
+# For example, this uses vault-tool, a random old package unlikely to be added to stackage.
+assert ! stacklock.pkgSet.vault-tool.passthru ? stacklock2nix;
+
 stacklock.newPkgSet.my-example-haskell-app


### PR DESCRIPTION
Expose some additional `passthru` values on Haskell derivations generated with stacklock2nix.

All Haskell derivations generated with `stacklock2nix` now have a `passthru.stacklock2nix` key, which is an attrset filled with the following keys.  All keys have a `Bool` value:

- `is-local-pkg`: Is this a local package defined in `stack.yaml`?
- `is-extra-dep`: Is this an `extra-dep` defined in `stack.yaml`?
- `is-hackage-dep`: Is this a dep from Hackage?
- `is-git-dep`: Is this a dep from Git?
- `is-url-dep`: Is this a dep from a URL?

See the tests added in this PR for some examples of how to use these new keys.