### PR TITLE
Add os-string to "shipped with GHC" libraries

### DIFF
--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -1001,6 +1001,7 @@ let
     ghc-boot-th = null;
     ghc-compact = null;
     ghc-heap = null;
+    ghc-internal = null;
     ghc-prim = null;
     ghci = null;
     haskeline = null;

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -1008,6 +1008,7 @@ let
     integer-gmp = null;
     libiserv = null;
     mtl = null;
+    os-string = null;
     parsec = null;
     pretty = null;
     process = null;


### PR DESCRIPTION
This is the library itself: https://github.com/haskell/os-string.