### PR TITLE
Use all-cabal-nixes to improve IFD speed a little

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,30 @@
 
+## 5.2.0
+
+*   Adds `all-cabal-nixes` argument to stacklock2nix.  This gives an
+    improvement on initial build time when using stacklock2nix with a shared
+    cache.
+
+    The `all-cabal-nixes` argument can be used like the following:
+
+    ```nix
+    stacklock2nix {
+      stackYaml = ./stack.yaml;
+      all-cabal-nixes = fetchFromGitHub {
+        owner = "all-cabal-nixes";
+        repo = "all-cabal-nixes";
+        rev = "c37e66df270014a18ed11527db55928a4a2ae5d4";
+        sha256 = "sha256-QcAhW8yFGwj7L1LWbvjdSQ2bTDeQ+1DVeC+/jS4gJA4=";
+      };
+    }
+    ```
+
+    This greatly reduces the amount of IFD needed for building packages from
+    Hackage.
+
+    See the PR adding this feature for more information:
+    [#65](https://github.com/cdepillabout/stacklock2nix/pull/65)
+
 ## 5.1.0
 
 *   Adds `os-string` and `ghc-internal` to list of GHC boot libraries.  This is

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -424,7 +424,7 @@ let
   #   hfinal
   # ```
   #
-  # This takes care of replaces the `.cabal` file from Hackage with the correct revision
+  # This takes care of replacing the `.cabal` file from Hackage with the correct revision
   # specified in the Hackage lock info.
   pkgHackageInfoToNixHaskPkg = isExtraDep: pkgHackageInfo: hfinal:
     let
@@ -449,7 +449,8 @@ let
   # Return a derivation for a Haskell package for the given Haskell package
   # lock info.
   #
-  # extraDepCreateNixHaskPkg :: Bool -> HaskellPkgSet -> HaskellPkgLock -> HaskellPkgDrv
+  # extraDepCreateNixHaskPkg ::
+  #   Bool -> HaskellPkgSet -> HaskellPkgLock -> { name :: String, value :: HaskellPkgDrv }
   #
   # The first `Bool` is `true` if the passed-in HaskellPkgLock is an
   # `extra-deps` from `stack.yaml`.  Otherwise, `false` if the passed-in

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -221,10 +221,10 @@ let
   readYAML = callPackage ./read-yaml.nix {};
 
   # The `stack.yaml` file read in as a Nix value.
-  stackYamlParsed = readYAML stackYamlReal;
+  stackYamlParsed = readYAML "stack.yaml" stackYamlReal;
 
   # The `stack.yaml.lock` file read in as a Nix value.
-  stackYamlLockParsed = readYAML stackYamlLockReal;
+  stackYamlLockParsed = readYAML "stack.yaml.lock" stackYamlLockReal;
 
   # The URL and sha256 for the snapshot from the `stack.yaml.lock` file.
   #
@@ -247,7 +247,7 @@ let
 
   # The Nix value for the Stackage snapshot specified in the `stack.yaml.lock`
   # file.
-  resolverParsed = readYAML resolverRawYaml;
+  resolverParsed = readYAML "stackage-resolver" resolverRawYaml;
 
   # Fetch cabal revisions from the stackage content addressable store.
   fetchCabalFileRevision = {name, version, hash}:
@@ -719,7 +719,7 @@ let
       # Example: `"my-cool-pkg"`
       pkgNameFromPackageYaml =
         let
-          packageYaml = readYAML (justCabalFilePath + "/package.yaml");
+          packageYaml = readYAML (baseNameOf rawPkgPath + "-package.yaml") (justCabalFilePath + "/package.yaml");
         in
         if packageYaml ? name then
           packageYaml.name

--- a/nix/build-support/stacklock2nix/read-yaml.nix
+++ b/nix/build-support/stacklock2nix/read-yaml.nix
@@ -9,10 +9,14 @@
 #
 # but takes an input file in YAML instead of JSON.
 #
-# readYAML :: Path -> a
-#
-# where `a` is the Nixified version of the input file.
-path:
+# readYAML ::
+#   -- | The name to use in the output derivation.  Helpful for debugging.
+#   String ->
+#   -- | The path of the actual YAML file to turn into JSON.
+#   Path ->
+#   -- | The nixified version of the input YAML file.
+#   a
+drvName: path:
 
 let
   # Starting in remarshal-0.17.0, it added a new `--stringify` CLI flag:
@@ -28,7 +32,7 @@ let
 
   jsonOutputDrv =
     runCommand
-      "from-yaml"
+      "from-yaml-${drvName}"
       { nativeBuildInputs = [ remarshal ]; }
       "remarshal ${remarshal-stringify-arg} -if yaml -i \"${path}\" -of json -o \"$out\"";
 in

--- a/test/nixpkgs.nix
+++ b/test/nixpkgs.nix
@@ -28,6 +28,9 @@ let
         # This also tests that our stacklock2nix-specific passthru values are working.
         all-cabal-hashes-is-dir = final.callPackage ./test-all-cabal-hashes-is-dir.nix {};
 
+        # This tests that the all-cabal-nixes argument works correctly.
+        all-cabal-nixes = final.callPackage ./test-all-cabal-nixes.nix {};
+
         # This test that a stack.yaml with no local packages defined is still
         # able to be used by stacklock2nix, and produces a reasonable package set.
         no-local-packages = final.callPackage ./test-no-local-packages {};

--- a/test/test-all-cabal-nixes.nix
+++ b/test/test-all-cabal-nixes.nix
@@ -1,0 +1,46 @@
+{ lib
+, stacklock2nix
+, haskell
+, cabal-install
+, fetchFromGitHub
+}:
+
+let
+  hasklib = haskell.lib.compose;
+
+  stacklock = stacklock2nix {
+    stackYaml = ../my-example-haskell-lib-easy/stack.yaml;
+    baseHaskellPkgSet = haskell.packages.ghc984;
+    additionalHaskellPkgSetOverrides = hfinal: hprev: {
+      # The servant-cassava.cabal file is malformed on GitHub:
+      # https://github.com/haskell-servant/servant-cassava/pull/29
+      servant-cassava =
+        hasklib.overrideCabal
+          { editedCabalFile = null; revision = null; }
+          hprev.servant-cassava;
+
+      amazonka = hasklib.dontCheck hprev.amazonka;
+      amazonka-core = hasklib.dontCheck hprev.amazonka-core;
+      amazonka-sso = hasklib.dontCheck hprev.amazonka-sso;
+      amazonka-sts = hasklib.dontCheck hprev.amazonka-sts;
+    };
+    cabal2nixArgsOverrides = args: args // {
+      amazonka-sso = ver: { amazonka-test = null; };
+      amazonka-sts = ver: { amazonka-test = null; };
+    };
+    all-cabal-hashes = fetchFromGitHub {
+      owner = "commercialhaskell";
+      repo = "all-cabal-hashes";
+      rev = "578b09df5072f21768cfe13edfc3e4c3e41428fc";
+      sha256 = "sha256-fmf4LukOJ2c0bCmNfuN+n2R6bxGhJqag9CBvZQEl3kA=";
+    };
+    # This test is to confirm that using `all-cabal-nixes` works.
+    all-cabal-nixes = fetchFromGitHub {
+      owner = "all-cabal-nixes";
+      repo = "all-cabal-nixes";
+      rev = "c37e66df270014a18ed11527db55928a4a2ae5d4";
+      sha256 = "sha256-QcAhW8yFGwj7L1LWbvjdSQ2bTDeQ+1DVeC+/jS4gJA4=";
+    };
+  };
+in
+stacklock.newPkgSet.my-example-haskell-app


### PR DESCRIPTION
This PR adds a new argument to stacklock2nix: `all-cabal-nixes`.

This argument takes a derivation providing the [`all-cabal-nixes`](https://github.com/all-cabal-nixes/all-cabal-nixes) repo.  This repo is the result of running `cabal2nix` on all the `.cabal` files in [`all-cabal-hashes`](https://github.com/commercialhaskell/all-cabal-hashes).

stacklock2nix internally calls `callHackage` on all the dependencies coming from Hackage (for instance deps from both the Stackage resolver as well as `extra-deps).  Using `all-cabal-nixes` can eliminate the need for `callHackage` and (some?) IFD.

See the CHANGELOG and new documentation in this PR for more info.

This is related to #41.

This also uses @lf-'s `some-cabal-hashes` idea from https://jade.fyi/blog/nix-evaluation-blocking/ to collect all the `cabal2nix` output for the given Stackage resolver and extra-deps into a separate derivation.  This enables initial builds with a shared Nix cache to be a little quicker, since only this new `some-cabal-nixes` needs to be downloaded from the cache (instead of the full `all-cabal-nixes` or `all-cabal-hashes`).