### PR TITLE
Update override for `test-framework`

### DIFF
--- a/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
+++ b/nix/build-support/stacklock2nix/cabal2nixArgsForPkg.nix
@@ -125,7 +125,11 @@ cabal2nixArgsOverrides {
     else
       {};
 
-  "test-framework" = ver: { libxml = pkgs.libxml; };
+  "test-framework" = ver:
+    if pkgs.lib.versionAtLeast ver "0.8.1.1" then
+      {}
+    else
+      { libxml = pkgs.libxml; };
 
   "termonad" = ver: { vte_291 = pkgs.vte; gtk3 = pkgs.gtk3; pcre2 = pkgs.pcre2;};
 


### PR DESCRIPTION
Starting with `0.8.1.1`, `libxml` is not used.