### PR TITLE
Fix: "builder for '/nix/store/...-some-cabal-nixes.drv' failed with exit code 1" when last package is a duplicate

### DIFF
--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -520,6 +520,7 @@ let
           mkdir -p "$out"
           cd "$out"
           ${lib.concatMapStrings copyForPkg pkgs}
+          # the derivation must not fail in case the very last `copyForPkg` fails
           true
         '';
 

--- a/nix/build-support/stacklock2nix/default.nix
+++ b/nix/build-support/stacklock2nix/default.nix
@@ -520,6 +520,7 @@ let
           mkdir -p "$out"
           cd "$out"
           ${lib.concatMapStrings copyForPkg pkgs}
+          true
         '';
 
   # Similar to callHackage, but instead of internally running cabal2nix, it


### PR DESCRIPTION
Posix shells are great, aren't they